### PR TITLE
docs: add ClawHub skill compatibility notes

### DIFF
--- a/docs/concepts/skills.md
+++ b/docs/concepts/skills.md
@@ -99,6 +99,17 @@ prompt: |
 ::: tip
 Skills encapsulate both *knowledge* (instructions) and *specialized tools* for a specific domain. This follows the "Atomic Skill-Level Healing" principle where detection and recovery are bundled together.
 :::
+
+## ClawHub Compatibility
+
+OpenViber is compatible with the **ClawHub** skill bundle spec so skills can be imported directly without conversion. Concretely:
+
+- A ClawHub skill bundle **must include `SKILL.md` at the bundle root**, and OpenViber uses the frontmatter + body as the skill definition.
+- Optional files (CLI helpers, configs, assets) are kept intact; OpenViber ignores unknown metadata and only loads the pieces it understands.
+- If the bundle exposes tools via `index.ts`, OpenViber loads those tools alongside the SKILL.md instructions.
+
+This keeps OpenViber stateless while allowing teams to share and reuse skills from `https://clawhub.ai/` across environments.
+
 ## Built-in Skills
 
 | Skill | Purpose |

--- a/docs/design/plan-and-artifacts.md
+++ b/docs/design/plan-and-artifacts.md
@@ -77,6 +77,7 @@ Both keep plan and artifacts on the client; the agent consumes them as context a
 | **~/.openviber/**   | `agents/{id}.yaml` (config), `agents/{id}/sessions/*.jsonl`        | User / daemon         | Daemon, tooling                           |
 | **~/.openviber/workspace/** | `task.md` (or other plan), `MEMORY.md`, `memory/YYYY-MM-DD.md`, artifacts checked into workspace if desired | Daemon, user, Board UI | Daemon, Board UI                          |
 | **~/.openviber/artifacts/{taskId}/`** | Large blobs produced during tasks (screens, logs) | Daemon                | Daemon (writes), Board via refs           |
+| **~/.openviber/skills/** | Skill bundles (ClawHub-compatible) cached locally | User / tooling | Daemon, tooling |
 | **Viber Board cache** | Optional message cache for UI performance                    | Board                 | Board                                     |
 
 Conversation/task continuity is guaranteed by the filesystem workspace; the daemon process can restart freely.
@@ -129,7 +130,7 @@ Conversation/task continuity is guaranteed by the filesystem workspace; the daem
 │   └── artifacts/                   # optional in-workspace artifacts
 ├── artifacts/{taskId}/              # large blobs created by daemon
 ├── memory/{agentId}.sqlite          # semantic index of memory/*.md (optional)
-└── skills/                          # downloaded/installed skills cache
+└── skills/                          # downloaded/installed skills cache (ClawHub-compatible bundles)
 ```
 
 ---


### PR DESCRIPTION
### Motivation
- Make OpenViber explicitly compatible with the ClawHub skill bundle spec so teams can import/share skill bundles directly (reduce friction when reusing community skills).

### Description
- Document ClawHub compatibility in `docs/concepts/skills.md`, including that a ClawHub bundle must include `SKILL.md` at the bundle root and that optional files (CLI helpers, assets) are ignored unless `index.ts` exposes tools to load alongside the SKILL.md instructions; changed file: `docs/concepts/skills.md`.
- Note local skill cache support in the workspace layout and call out `~/.openviber/skills/` as the place for ClawHub-compatible bundles in `docs/design/plan-and-artifacts.md`.

### Testing
- No automated tests were run because this is a documentation-only change; changes are limited to `docs/concepts/skills.md` and `docs/design/plan-and-artifacts.md` and a doc commit was created successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698352e0e560832e9d5f9b8971a0bfb6)