### PR TITLE
fix(web): hide unnecessary horizontal scrollbar in docs pages

### DIFF
--- a/web/src/routes/docs/+layout.svelte
+++ b/web/src/routes/docs/+layout.svelte
@@ -815,6 +815,7 @@
   .docs-content-scroll {
     min-height: 0;
     overflow-y: auto;
+    overflow-x: hidden;
     padding-right: 0.1rem;
   }
 


### PR DESCRIPTION
### Motivation
- The documentation pages displayed a persistent horizontal scrollbar that disrupted normal vertical scrolling; the content scroll container should prevent horizontal overflow.

### Description
- Added `overflow-x: hidden;` to the `.docs-content-scroll` rule in `web/src/routes/docs/+layout.svelte` to hide horizontal overflow.

### Testing
- Ran `pnpm --filter @openviber/web check` and attempted `pnpm dev --host 0.0.0.0 --port 4173`, but both were blocked by unrelated pre-existing issues (missing `paneforge` and duplicate export/type resolution problems), so visual verification could not be completed; the change is CSS-only and scoped to the docs layout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984b1e0bdc0832ebb41db3ba1a93f21)