### PR TITLE
feat: stream task progress and partial responses to board

### DIFF
--- a/docs/design/communication.md
+++ b/docs/design/communication.md
@@ -32,16 +32,16 @@ Daemon -> Board:
 - `task:completed` (`summary`, `artifactRefs`, `verificationRefs`)
 - `task:error`
 
-## 3. Runtime observability messages (tmux)
+## 3. Runtime observability messages (tmux-first, multi-app ready)
 
-- `terminal:list`
-- `terminal:attach`
-- `terminal:output`
-- `terminal:input`
-- `terminal:resize`
-- `terminal:detach`
+- `terminal:list` (returns `apps[]`, `sessions[]`, `panes[]`)
+- `terminal:attach` (`target`, optional `appId`)
+- `terminal:output` (`target`, optional `appId`, `data`)
+- `terminal:input` (`target`, optional `appId`, `keys`)
+- `terminal:resize` (`target`, optional `appId`, `cols`, `rows`)
+- `terminal:detach` (`target`, optional `appId`)
 
-These expose execution state without requiring GUI remoting.
+`tmux` is the default primary runtime. `appId` enables incremental support for other terminal-capable runtimes while preserving the same board contract.
 
 ## 4. Reporting envelope
 

--- a/src/daemon/controller.ts
+++ b/src/daemon/controller.ts
@@ -75,10 +75,10 @@ export type ControllerServerMessage =
   | { type: "config:update"; config: Partial<ViberControllerConfig> }
   // Terminal streaming messages
   | { type: "terminal:list" }
-  | { type: "terminal:attach"; target: string }
-  | { type: "terminal:detach"; target: string }
-  | { type: "terminal:input"; target: string; keys: string }
-  | { type: "terminal:resize"; target: string; cols: number; rows: number };
+  | { type: "terminal:attach"; target: string; appId?: string }
+  | { type: "terminal:detach"; target: string; appId?: string }
+  | { type: "terminal:input"; target: string; keys: string; appId?: string }
+  | { type: "terminal:resize"; target: string; cols: number; rows: number; appId?: string };
 
 // Viber -> Server messages
 export type ControllerClientMessage =
@@ -90,11 +90,11 @@ export type ControllerClientMessage =
   | { type: "heartbeat"; status: ViberStatus }
   | { type: "pong" }
   // Terminal streaming messages
-  | { type: "terminal:list"; sessions: any[]; panes: any[] }
-  | { type: "terminal:attached"; target: string; ok: boolean; error?: string }
-  | { type: "terminal:detached"; target: string }
-  | { type: "terminal:output"; target: string; data: string }
-  | { type: "terminal:resized"; target: string; ok: boolean };
+  | { type: "terminal:list"; apps: any[]; sessions: any[]; panes: any[] }
+  | { type: "terminal:attached"; target: string; appId?: string; ok: boolean; error?: string }
+  | { type: "terminal:detached"; target: string; appId?: string }
+  | { type: "terminal:output"; target: string; appId?: string; data: string }
+  | { type: "terminal:resized"; target: string; appId?: string; ok: boolean };
 
 // ==================== Controller ====================
 
@@ -277,19 +277,19 @@ export class ViberController extends EventEmitter {
           break;
 
         case "terminal:attach":
-          await this.handleTerminalAttach(message.target);
+          await this.handleTerminalAttach(message.target, message.appId);
           break;
 
         case "terminal:detach":
-          this.handleTerminalDetach(message.target);
+          this.handleTerminalDetach(message.target, message.appId);
           break;
 
         case "terminal:input":
-          this.handleTerminalInput(message.target, message.keys);
+          this.handleTerminalInput(message.target, message.keys, message.appId);
           break;
 
         case "terminal:resize":
-          this.handleTerminalResize(message.target, message.cols, message.rows);
+          this.handleTerminalResize(message.target, message.cols, message.rows, message.appId);
           break;
       }
     } catch (error) {
@@ -331,8 +331,90 @@ export class ViberController extends EventEmitter {
         messages
       );
 
-      // Consume stream to completion; do not send intermediate chunks to Viber Board by default.
-      const finalText = await streamResult.text;
+      let finalText = "";
+      let pendingDelta = "";
+      let lastProgressAt = 0;
+      const flushProgress = (force = false): void => {
+        if (!pendingDelta) return;
+        const now = Date.now();
+        if (!force && now - lastProgressAt < 250) return;
+
+        this.send({
+          type: "task:progress",
+          taskId,
+          event: {
+            kind: "text-delta",
+            delta: pendingDelta,
+            totalLength: finalText.length,
+            at: new Date(now).toISOString(),
+          },
+        });
+        pendingDelta = "";
+        lastProgressAt = now;
+      };
+
+      this.send({
+        type: "task:progress",
+        taskId,
+        event: {
+          kind: "status",
+          phase: "executing",
+          message: "Agent execution started",
+          at: new Date().toISOString(),
+        },
+      });
+
+      for await (const part of streamResult.fullStream) {
+        switch (part.type) {
+          case "text-delta":
+            if (part.text) {
+              finalText += part.text;
+              pendingDelta += part.text;
+              flushProgress(false);
+            }
+            break;
+          case "tool-call":
+            this.send({
+              type: "task:progress",
+              taskId,
+              event: {
+                kind: "tool-call",
+                toolName: part.toolName,
+                toolCallId: part.toolCallId,
+                at: new Date().toISOString(),
+              },
+            });
+            break;
+          case "tool-result":
+            this.send({
+              type: "task:progress",
+              taskId,
+              event: {
+                kind: "tool-result",
+                toolCallId: part.toolCallId,
+                at: new Date().toISOString(),
+              },
+            });
+            break;
+          case "error":
+            throw new Error(part.error?.message || "Task stream error");
+          case "finish":
+            flushProgress(true);
+            this.send({
+              type: "task:progress",
+              taskId,
+              event: {
+                kind: "status",
+                phase: "verifying",
+                message: "Agent execution finished, preparing final output",
+                at: new Date().toISOString(),
+              },
+            });
+            break;
+          default:
+            break;
+        }
+      }
 
       this.send({
         type: "task:completed",
@@ -378,41 +460,43 @@ export class ViberController extends EventEmitter {
   // ==================== Terminal Streaming ====================
 
   private handleTerminalList(): void {
-    const { sessions, panes } = this.terminalManager.list();
-    this.send({ type: "terminal:list", sessions, panes });
+    const { apps, sessions, panes } = this.terminalManager.list();
+    this.send({ type: "terminal:list", apps, sessions, panes });
   }
 
-  private async handleTerminalAttach(target: string): Promise<void> {
+  private async handleTerminalAttach(target: string, appId?: string): Promise<void> {
     console.log(`[Viber] Attaching to terminal: ${target}`);
     const ok = await this.terminalManager.attach(
       target,
       (data) => {
-        this.send({ type: "terminal:output", target, data });
+        this.send({ type: "terminal:output", target, appId, data });
       },
       () => {
-        this.send({ type: "terminal:detached", target });
-      }
+        this.send({ type: "terminal:detached", target, appId });
+      },
+      appId
     );
-    this.send({ type: "terminal:attached", target, ok });
+    this.send({ type: "terminal:attached", target, appId, ok });
   }
 
-  private handleTerminalDetach(target: string): void {
+  private handleTerminalDetach(target: string, appId?: string): void {
     console.log(`[Viber] Detaching from terminal: ${target}`);
-    this.terminalManager.detach(target);
-    this.send({ type: "terminal:detached", target });
+    this.terminalManager.detach(target, appId);
+    this.send({ type: "terminal:detached", target, appId });
   }
 
-  private handleTerminalInput(target: string, keys: string): void {
-    this.terminalManager.sendInput(target, keys);
+  private handleTerminalInput(target: string, keys: string, appId?: string): void {
+    this.terminalManager.sendInput(target, keys, appId);
   }
 
   private handleTerminalResize(
     target: string,
     cols: number,
-    rows: number
+    rows: number,
+    appId?: string
   ): void {
-    const ok = this.terminalManager.resize(target, cols, rows);
-    this.send({ type: "terminal:resized", target, ok });
+    const ok = this.terminalManager.resize(target, cols, rows, appId);
+    this.send({ type: "terminal:resized", target, appId, ok });
   }
 
   // ==================== Communication ====================

--- a/src/daemon/hub.integration.test.ts
+++ b/src/daemon/hub.integration.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Integration test for hub task progress streaming state.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import WebSocket from "ws";
+import { HubServer } from "./hub";
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("hub task progress integration", () => {
+  let hub: HubServer | null = null;
+
+  afterEach(async () => {
+    if (hub) {
+      await hub.stop();
+      hub = null;
+    }
+  });
+
+  it("stores task progress events and partial text for board polling", async () => {
+    const port = 6707;
+    hub = new HubServer({ port });
+    await hub.start();
+
+    const ws = new WebSocket(`ws://localhost:${port}/ws`, {
+      headers: {
+        "x-viber-id": "test-viber",
+      },
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      ws.once("open", () => resolve());
+      ws.once("error", reject);
+    });
+
+    ws.send(
+      JSON.stringify({
+        type: "connected",
+        viber: {
+          id: "test-viber",
+          name: "Test Viber",
+          version: "1.0.0",
+          platform: process.platform,
+          capabilities: [],
+          runningTasks: [],
+        },
+      }),
+    );
+
+    const submit = await fetch(`http://localhost:${port}/api/vibers`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ goal: "stream me", viberId: "test-viber" }),
+    });
+    expect(submit.ok).toBe(true);
+    const { taskId } = (await submit.json()) as { taskId: string };
+
+    ws.send(
+      JSON.stringify({
+        type: "task:progress",
+        taskId,
+        event: { kind: "text-delta", delta: "hello " },
+      }),
+    );
+    ws.send(
+      JSON.stringify({
+        type: "task:progress",
+        taskId,
+        event: { kind: "text-delta", delta: "world" },
+      }),
+    );
+
+    await wait(80);
+
+    const taskRes = await fetch(`http://localhost:${port}/api/tasks/${taskId}`);
+    expect(taskRes.ok).toBe(true);
+    const task = (await taskRes.json()) as {
+      eventCount: number;
+      partialText?: string;
+      events?: Array<{ event?: { kind?: string } }>;
+    };
+
+    expect(task.eventCount).toBeGreaterThanOrEqual(2);
+    expect(task.partialText).toContain("hello world");
+    expect(task.events?.some((e) => e.event?.kind === "text-delta")).toBe(true);
+
+    ws.close();
+  });
+});

--- a/src/daemon/terminal.integration.test.ts
+++ b/src/daemon/terminal.integration.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Integration tests for terminal runtime adapters.
+ *
+ * Verifies tmux-first behavior and fallback adapter support for extending
+ * Viber Board use cases across terminal-like app runtimes.
+ */
+
+import { describe, expect, it } from "vitest";
+import { execSync } from "child_process";
+import { TerminalManager } from "./terminal";
+
+function hasTmux(): boolean {
+  try {
+    execSync("tmux -V", { stdio: "pipe" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("terminal manager integration", () => {
+  it("lists app metadata and keeps tmux as the primary adapter", () => {
+    const manager = new TerminalManager();
+    const result = manager.list();
+
+    expect(result.apps.length).toBeGreaterThanOrEqual(2);
+    expect(result.apps.some((app) => app.id === "tmux")).toBe(true);
+    expect(result.apps.some((app) => app.id === "shell")).toBe(true);
+  });
+
+  it("creates and drives shell sessions as fallback app", async () => {
+    const manager = new TerminalManager();
+    const created = manager.createSession("integration-shell", "main", process.cwd(), "shell");
+
+    expect(created.ok).toBe(true);
+    expect(created.appId).toBe("shell");
+
+    const listed = manager.list();
+    const pane = listed.panes.find((p) => p.appId === "shell" && p.session === created.sessionName);
+    expect(pane).toBeDefined();
+
+    const attached = await manager.attach(
+      pane!.target,
+      () => {
+        // no-op
+      },
+      () => {
+        // no-op
+      },
+      "shell",
+    );
+
+    expect(attached).toBe(true);
+    expect(manager.sendInput(pane!.target, "echo VIBER_SHELL_TEST\n", "shell")).toBe(true);
+    expect(manager.resize(pane!.target, 120, 40, "shell")).toBe(true);
+
+    manager.detachAll();
+  });
+
+  it.skipIf(!hasTmux())("creates tmux session and routes input/resize", async () => {
+    const manager = new TerminalManager();
+    const created = manager.createSession("integration-tmux", "main", process.cwd(), "tmux");
+    expect(created.ok).toBe(true);
+
+    const listed = manager.list();
+    const pane = listed.panes.find((p) => p.appId === "tmux" && p.session === created.sessionName);
+    expect(pane).toBeDefined();
+
+    const attached = await manager.attach(
+      pane!.target,
+      () => {
+        // no-op
+      },
+      () => {
+        // no-op
+      },
+      "tmux",
+    );
+    expect(attached).toBe(true);
+
+    expect(manager.sendInput(pane!.target, "echo VIBER_TMUX_TEST\n", "tmux")).toBe(true);
+    expect(manager.resize(pane!.target, 120, 40, "tmux")).toBe(true);
+
+    manager.detachAll();
+    execSync(`tmux kill-session -t '${created.sessionName}'`, { stdio: "pipe" });
+  });
+});

--- a/src/daemon/terminal.ts
+++ b/src/daemon/terminal.ts
@@ -1,228 +1,93 @@
 /**
- * Terminal streaming module - pipe tmux panes to WebSocket
+ * Terminal runtime abstraction.
  *
- * Provides:
- * - List tmux sessions/windows/panes
- * - Attach to a pane (start streaming output)
- * - Send input to a pane
- * - Detach from a pane (stop streaming)
+ * tmux remains the primary backend, while additional app adapters can be
+ * plugged in for other execution surfaces.
  */
 
 import { spawn, spawnSync, execSync, ChildProcess } from "child_process";
 import { EventEmitter } from "events";
+import { randomUUID } from "crypto";
 
-export interface TmuxPane {
+export interface TerminalPane {
+  appId: string;
   session: string;
   window: string;
   windowName: string;
   pane: string;
   command: string;
-  target: string; // e.g. "coding:1.0"
+  target: string;
 }
 
-export interface TmuxSession {
+export interface TerminalSession {
+  appId: string;
   name: string;
   windows: number;
   attached: boolean;
 }
 
+export interface CreateSessionResult {
+  ok: boolean;
+  appId: string;
+  sessionName: string;
+  created: boolean;
+  error?: string;
+}
+
+export interface TerminalApp {
+  id: string;
+  label: string;
+  isAvailable(): boolean;
+  listSessions(): TerminalSession[];
+  listPanes(): TerminalPane[];
+  attach(
+    target: string,
+    onData: (data: string) => void,
+    onClose: () => void,
+  ): Promise<boolean>;
+  detach(target: string): void;
+  sendInput(target: string, keys: string): boolean;
+  resize(target: string, cols: number, rows: number): boolean;
+  createSession(sessionName: string, windowName?: string, cwd?: string): CreateSessionResult;
+  detachAll(): void;
+}
+
 const SAFE_NAME_RE = /[^a-zA-Z0-9_.:-]/g;
 
-function sanitizeTmuxName(input: string): string {
+function sanitizeName(input: string): string {
   return input.replace(SAFE_NAME_RE, "-");
 }
 
-/**
- * List all tmux sessions
- */
-export function listSessions(): TmuxSession[] {
-  try {
-    const out = execSync(
-      "tmux list-sessions -F '#{session_name}|#{session_windows}|#{session_attached}' 2>/dev/null",
-      { encoding: "utf8", stdio: "pipe" }
-    ).trim();
-    if (!out) return [];
-    return out.split("\n").map((line) => {
-      const [name, windows, attached] = line.split("|");
-      return {
-        name,
-        windows: parseInt(windows, 10) || 0,
-        attached: attached === "1",
-      };
-    });
-  } catch {
-    return [];
+function resolveAppTarget(target: string, appHint?: string): { appId: string; rawTarget: string } {
+  if (target.includes("::")) {
+    const [appId, ...rest] = target.split("::");
+    return { appId, rawTarget: rest.join("::") };
   }
+  return { appId: appHint || "tmux", rawTarget: target };
 }
 
-/**
- * Create a detached tmux session if it doesn't already exist.
- */
-export function createSession(
-  sessionName: string,
-  windowName = "main",
-  cwd?: string
-): { ok: boolean; sessionName: string; created: boolean; error?: string } {
-  const safeSession = sanitizeTmuxName(sessionName || "coding");
-  const safeWindow = sanitizeTmuxName(windowName || "main");
-
-  try {
-    // Session already exists
-    execSync(`tmux has-session -t '${safeSession}' 2>/dev/null`, {
-      stdio: "pipe",
-    });
-    return { ok: true, sessionName: safeSession, created: false };
-  } catch {
-    // Continue to creation path
-  }
-
-  const args = ["new-session", "-d", "-s", safeSession, "-n", safeWindow];
-  if (cwd) {
-    args.push("-c", cwd);
-  }
-
-  const result = spawnSync("tmux", args, {
-    encoding: "utf8",
-    stdio: "pipe",
-  });
-
-  if (result.error) {
-    return {
-      ok: false,
-      sessionName: safeSession,
-      created: false,
-      error: `Failed to start tmux: ${result.error.message}`,
-    };
-  }
-
-  if (result.status !== 0) {
-    return {
-      ok: false,
-      sessionName: safeSession,
-      created: false,
-      error: (result.stderr || result.stdout || "Failed to create tmux session").trim(),
-    };
-  }
-
-  return { ok: true, sessionName: safeSession, created: true };
-}
-
-/**
- * List all panes across all sessions
- */
-export function listPanes(): TmuxPane[] {
-  try {
-    const out = execSync(
-      "tmux list-panes -a -F '#{session_name}|#{window_index}|#{window_name}|#{pane_index}|#{pane_current_command}' 2>/dev/null",
-      { encoding: "utf8", stdio: "pipe" }
-    ).trim();
-    if (!out) return [];
-    return out.split("\n").map((line) => {
-      const [session, window, windowName, pane, command] = line.split("|");
-      return {
-        session,
-        window,
-        windowName,
-        pane,
-        command,
-        target: `${session}:${window}.${pane}`,
-      };
-    });
-  } catch {
-    return [];
-  }
-}
-
-/**
- * Send keys to a tmux target
- */
-export function sendKeys(target: string, keys: string, pressEnter = false): boolean {
-  try {
-    const args = ["send-keys", "-t", target, keys];
-    if (pressEnter) args.push("Enter");
-    execSync(`tmux ${args.map((a) => `'${a}'`).join(" ")}`, {
-      encoding: "utf8",
-      stdio: "pipe",
-    });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Capture current pane content (snapshot)
- * -p : print to stdout
- * -e : include escape sequences (preserve colors/styles)
- * -a : include alternate screen (for curses/TTY TUIs)
- * We avoid -J so we don't drop carriage returns that the terminal needs.
- */
-export function capturePane(target: string, lines = 500): string {
-  const cmds = [
-    `tmux capture-pane -t '${target}' -pae -S -${lines}`,
-    `tmux capture-pane -t '${target}' -pe -S -${lines}`,
-  ];
-  for (const cmd of cmds) {
-    try {
-      return execSync(cmd, { encoding: "utf8", stdio: "pipe" });
-    } catch {
-      // try next fallback
-    }
-  }
-  return "";
-}
-
-/**
- * Resize a tmux pane to requested cols/rows.
- */
-export function resizePane(target: string, cols: number, rows: number): boolean {
-  try {
-    execSync(`tmux resize-pane -t '${target}' -x ${cols} -y ${rows}`, {
-      encoding: "utf8",
-      stdio: "pipe",
-    });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * TerminalStream - streams a tmux pane's output
- *
- * Uses `tmux pipe-pane` to pipe output to a subprocess that we read from.
- * Emits 'data' events with the output chunks.
- */
-export class TerminalStream extends EventEmitter {
-  private target: string;
+/** tmux app adapter */
+class TmuxTerminalStream extends EventEmitter {
   private catProcess: ChildProcess | null = null;
   private pipePath: string;
   private isAttached = false;
 
-  constructor(target: string) {
+  constructor(private target: string) {
     super();
-    this.target = target;
-    // Use a unique pipe path per target
     this.pipePath = `/tmp/viber-term-${target.replace(/[^a-zA-Z0-9]/g, "-")}-${Date.now()}`;
   }
 
-  /**
-   * Start streaming the pane output
-   */
   async attach(): Promise<boolean> {
     if (this.isAttached) return true;
 
     try {
-      // First, capture existing content (history)
-      const history = capturePane(this.target, 200);
+      const history = captureTmuxPane(this.target, 200);
       if (history) {
         this.emit("data", history);
       }
 
-      // Create named pipe
       execSync(`mkfifo '${this.pipePath}' 2>/dev/null || true`, { stdio: "pipe" });
 
-      // Start cat process to read from the pipe
       this.catProcess = spawn("cat", [this.pipePath], {
         stdio: ["ignore", "pipe", "ignore"],
       });
@@ -240,7 +105,6 @@ export class TerminalStream extends EventEmitter {
         this.cleanup();
       });
 
-      // Tell tmux to pipe the pane output to our named pipe
       execSync(`tmux pipe-pane -t '${this.target}' -o 'cat >> ${this.pipePath}'`, {
         encoding: "utf8",
         stdio: "pipe",
@@ -255,43 +119,27 @@ export class TerminalStream extends EventEmitter {
     }
   }
 
-  /**
-   * Stop streaming
-   */
   detach(): void {
     if (!this.isAttached) return;
-
     try {
-      // Stop tmux pipe
       execSync(`tmux pipe-pane -t '${this.target}'`, { stdio: "pipe" });
     } catch {
-      // Ignore errors
+      // ignore
     }
-
     this.cleanup();
-  }
-
-  /**
-   * Send input to the pane
-   */
-  sendInput(keys: string): boolean {
-    return sendKeys(this.target, keys, false);
   }
 
   private cleanup(): void {
     this.isAttached = false;
-
     if (this.catProcess) {
       this.catProcess.kill();
       this.catProcess = null;
     }
-
     try {
       execSync(`rm -f '${this.pipePath}'`, { stdio: "pipe" });
     } catch {
-      // Ignore
+      // ignore
     }
-
     this.emit("close");
   }
 
@@ -300,31 +148,70 @@ export class TerminalStream extends EventEmitter {
   }
 }
 
-/**
- * TerminalManager - manages multiple terminal streams
- */
-export class TerminalManager {
-  private streams: Map<string, TerminalStream> = new Map();
+class TmuxTerminalApp implements TerminalApp {
+  id = "tmux";
+  label = "tmux";
+  private streams: Map<string, TmuxTerminalStream> = new Map();
 
-  /**
-   * List all available terminals
-   */
-  list(): { sessions: TmuxSession[]; panes: TmuxPane[] } {
-    return {
-      sessions: listSessions(),
-      panes: listPanes(),
-    };
+  isAvailable(): boolean {
+    try {
+      execSync("tmux -V", { stdio: "pipe" });
+      return true;
+    } catch {
+      return false;
+    }
   }
 
-  /**
-   * Attach to a pane and return the stream
-   */
+  listSessions(): TerminalSession[] {
+    try {
+      const out = execSync(
+        "tmux list-sessions -F '#{session_name}|#{session_windows}|#{session_attached}' 2>/dev/null",
+        { encoding: "utf8", stdio: "pipe" },
+      ).trim();
+      if (!out) return [];
+      return out.split("\n").map((line) => {
+        const [name, windows, attached] = line.split("|");
+        return {
+          appId: this.id,
+          name,
+          windows: parseInt(windows, 10) || 0,
+          attached: attached === "1",
+        };
+      });
+    } catch {
+      return [];
+    }
+  }
+
+  listPanes(): TerminalPane[] {
+    try {
+      const out = execSync(
+        "tmux list-panes -a -F '#{session_name}|#{window_index}|#{window_name}|#{pane_index}|#{pane_current_command}' 2>/dev/null",
+        { encoding: "utf8", stdio: "pipe" },
+      ).trim();
+      if (!out) return [];
+      return out.split("\n").map((line) => {
+        const [session, window, windowName, pane, command] = line.split("|");
+        return {
+          appId: this.id,
+          session,
+          window,
+          windowName,
+          pane,
+          command,
+          target: `${session}:${window}.${pane}`,
+        };
+      });
+    } catch {
+      return [];
+    }
+  }
+
   async attach(
     target: string,
     onData: (data: string) => void,
-    onClose: () => void
+    onClose: () => void,
   ): Promise<boolean> {
-    // If already attached, just add listeners
     let stream = this.streams.get(target);
     if (stream && stream.attached) {
       stream.on("data", onData);
@@ -332,8 +219,7 @@ export class TerminalManager {
       return true;
     }
 
-    // Create new stream
-    stream = new TerminalStream(target);
+    stream = new TmuxTerminalStream(target);
     stream.on("data", onData);
     stream.on("close", () => {
       this.streams.delete(target);
@@ -347,50 +233,343 @@ export class TerminalManager {
     return ok;
   }
 
-  /**
-   * Detach from a pane
-   */
   detach(target: string): void {
     const stream = this.streams.get(target);
-    if (stream) {
-      stream.detach();
-      this.streams.delete(target);
+    if (!stream) return;
+    stream.detach();
+    this.streams.delete(target);
+  }
+
+  sendInput(target: string, keys: string): boolean {
+    return sendTmuxKeys(target, keys);
+  }
+
+  resize(target: string, cols: number, rows: number): boolean {
+    try {
+      execSync(`tmux resize-pane -t '${target}' -x ${cols} -y ${rows}`, {
+        encoding: "utf8",
+        stdio: "pipe",
+      });
+      return true;
+    } catch {
+      return false;
     }
   }
 
-  /**
-   * Send input to a pane
-   */
-  sendInput(target: string, keys: string): boolean {
-    // Can send input even without a stream attached
-    return sendKeys(target, keys, false);
+  createSession(sessionName: string, windowName = "main", cwd?: string): CreateSessionResult {
+    const safeSession = sanitizeName(sessionName || "coding");
+    const safeWindow = sanitizeName(windowName || "main");
+
+    try {
+      execSync(`tmux has-session -t '${safeSession}' 2>/dev/null`, { stdio: "pipe" });
+      return { ok: true, appId: this.id, sessionName: safeSession, created: false };
+    } catch {
+      // create
+    }
+
+    const args = ["new-session", "-d", "-s", safeSession, "-n", safeWindow];
+    if (cwd) {
+      args.push("-c", cwd);
+    }
+
+    const result = spawnSync("tmux", args, {
+      encoding: "utf8",
+      stdio: "pipe",
+    });
+
+    if (result.error) {
+      return {
+        ok: false,
+        appId: this.id,
+        sessionName: safeSession,
+        created: false,
+        error: `Failed to start tmux: ${result.error.message}`,
+      };
+    }
+
+    if (result.status !== 0) {
+      return {
+        ok: false,
+        appId: this.id,
+        sessionName: safeSession,
+        created: false,
+        error: (result.stderr || result.stdout || "Failed to create tmux session").trim(),
+      };
+    }
+
+    return { ok: true, appId: this.id, sessionName: safeSession, created: true };
   }
 
-  /**
-   * Resize pane to match web terminal
-   */
-  resize(target: string, cols: number, rows: number): boolean {
-    return resizePane(target, cols, rows);
-  }
-
-  /**
-   * Detach all streams
-   */
   detachAll(): void {
     for (const stream of this.streams.values()) {
       stream.detach();
     }
     this.streams.clear();
   }
+}
 
-  /**
-   * Create a detached tmux session for web-managed terminals.
-   */
+interface ShellProcessState {
+  proc: ChildProcess;
+  sessionName: string;
+  windowName: string;
+  pane: string;
+  history: string[];
+  listeners: Set<(data: string) => void>;
+  closeListeners: Set<() => void>;
+}
+
+/**
+ * Lightweight process-based adapter that keeps shell sessions available for
+ * environments where tmux is unavailable.
+ */
+class ShellTerminalApp implements TerminalApp {
+  id = "shell";
+  label = "shell";
+  private sessions = new Map<string, ShellProcessState>();
+
+  isAvailable(): boolean {
+    return true;
+  }
+
+  listSessions(): TerminalSession[] {
+    return Array.from(this.sessions.values()).map((state) => ({
+      appId: this.id,
+      name: state.sessionName,
+      windows: 1,
+      attached: state.listeners.size > 0,
+    }));
+  }
+
+  listPanes(): TerminalPane[] {
+    return Array.from(this.sessions.entries()).map(([id, state]) => ({
+      appId: this.id,
+      session: state.sessionName,
+      window: "0",
+      windowName: state.windowName,
+      pane: state.pane,
+      command: process.env.SHELL || "sh",
+      target: id,
+    }));
+  }
+
+  async attach(target: string, onData: (data: string) => void, onClose: () => void): Promise<boolean> {
+    const state = this.sessions.get(target);
+    if (!state) return false;
+
+    state.listeners.add(onData);
+    state.closeListeners.add(onClose);
+    if (state.history.length > 0) {
+      onData(state.history.join(""));
+    }
+    return true;
+  }
+
+  detach(target: string): void {
+    const state = this.sessions.get(target);
+    if (!state) return;
+    state.listeners.clear();
+    state.closeListeners.clear();
+  }
+
+  sendInput(target: string, keys: string): boolean {
+    const state = this.sessions.get(target);
+    if (!state || !state.proc.stdin?.writable) return false;
+    state.proc.stdin.write(keys);
+    return true;
+  }
+
+  resize(_target: string, _cols: number, _rows: number): boolean {
+    return true;
+  }
+
+  createSession(sessionName: string, windowName = "main", cwd?: string): CreateSessionResult {
+    const safeSession = sanitizeName(sessionName || `shell-${Date.now()}`);
+    const shell = process.env.SHELL || "sh";
+    const target = `${safeSession}:${randomUUID().slice(0, 8)}`;
+
+    if (this.sessions.has(target)) {
+      return { ok: true, appId: this.id, sessionName: safeSession, created: false };
+    }
+
+    const proc = spawn(shell, [], {
+      cwd,
+      stdio: ["pipe", "pipe", "pipe"],
+      env: process.env,
+    });
+
+    if (!proc.pid) {
+      return {
+        ok: false,
+        appId: this.id,
+        sessionName: safeSession,
+        created: false,
+        error: "Failed to start shell process",
+      };
+    }
+
+    const state: ShellProcessState = {
+      proc,
+      sessionName: safeSession,
+      windowName,
+      pane: "0",
+      history: [],
+      listeners: new Set(),
+      closeListeners: new Set(),
+    };
+
+    const pushChunk = (chunk: Buffer): void => {
+      const text = chunk.toString();
+      state.history.push(text);
+      if (state.history.length > 200) {
+        state.history.shift();
+      }
+      for (const listener of state.listeners) {
+        listener(text);
+      }
+    };
+
+    proc.stdout?.on("data", pushChunk);
+    proc.stderr?.on("data", pushChunk);
+    proc.on("close", () => {
+      for (const onClose of state.closeListeners) {
+        onClose();
+      }
+      this.sessions.delete(target);
+    });
+
+    this.sessions.set(target, state);
+
+    return { ok: true, appId: this.id, sessionName: safeSession, created: true };
+  }
+
+  detachAll(): void {
+    for (const [id, state] of this.sessions.entries()) {
+      state.proc.kill();
+      this.sessions.delete(id);
+    }
+  }
+}
+
+function sendTmuxKeys(target: string, keys: string, pressEnter = false): boolean {
+  try {
+    const args = ["send-keys", "-t", target, keys];
+    if (pressEnter) args.push("Enter");
+    execSync(`tmux ${args.map((a) => `'${a}'`).join(" ")}`, {
+      encoding: "utf8",
+      stdio: "pipe",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function captureTmuxPane(target: string, lines = 500): string {
+  const cmds = [
+    `tmux capture-pane -t '${target}' -pae -S -${lines}`,
+    `tmux capture-pane -t '${target}' -pe -S -${lines}`,
+  ];
+  for (const cmd of cmds) {
+    try {
+      return execSync(cmd, { encoding: "utf8", stdio: "pipe" });
+    } catch {
+      // try next fallback
+    }
+  }
+  return "";
+}
+
+export interface TerminalListResponse {
+  apps: Array<{ id: string; label: string; available: boolean }>;
+  sessions: TerminalSession[];
+  panes: TerminalPane[];
+}
+
+/**
+ * TerminalManager multiplexes app adapters and routes operations by app id.
+ */
+export class TerminalManager {
+  private readonly apps = new Map<string, TerminalApp>();
+
+  constructor(adapters?: TerminalApp[]) {
+    const defaultAdapters = adapters ?? [new TmuxTerminalApp(), new ShellTerminalApp()];
+    for (const adapter of defaultAdapters) {
+      this.apps.set(adapter.id, adapter);
+    }
+  }
+
+  list(): TerminalListResponse {
+    const metadata = Array.from(this.apps.values()).map((app) => ({
+      id: app.id,
+      label: app.label,
+      available: app.isAvailable(),
+    }));
+
+    const sessions: TerminalSession[] = [];
+    const panes: TerminalPane[] = [];
+
+    for (const app of this.apps.values()) {
+      if (!app.isAvailable()) continue;
+      sessions.push(...app.listSessions());
+      panes.push(...app.listPanes());
+    }
+
+    return { apps: metadata, sessions, panes };
+  }
+
+  async attach(
+    target: string,
+    onData: (data: string) => void,
+    onClose: () => void,
+    appHint?: string,
+  ): Promise<boolean> {
+    const { appId, rawTarget } = resolveAppTarget(target, appHint);
+    const app = this.apps.get(appId);
+    if (!app || !app.isAvailable()) return false;
+    return app.attach(rawTarget, onData, onClose);
+  }
+
+  detach(target: string, appHint?: string): void {
+    const { appId, rawTarget } = resolveAppTarget(target, appHint);
+    this.apps.get(appId)?.detach(rawTarget);
+  }
+
+  sendInput(target: string, keys: string, appHint?: string): boolean {
+    const { appId, rawTarget } = resolveAppTarget(target, appHint);
+    const app = this.apps.get(appId);
+    return !!app && app.isAvailable() ? app.sendInput(rawTarget, keys) : false;
+  }
+
+  resize(target: string, cols: number, rows: number, appHint?: string): boolean {
+    const { appId, rawTarget } = resolveAppTarget(target, appHint);
+    const app = this.apps.get(appId);
+    return !!app && app.isAvailable() ? app.resize(rawTarget, cols, rows) : false;
+  }
+
   createSession(
     sessionName: string,
     windowName = "main",
-    cwd?: string
-  ): { ok: boolean; sessionName: string; created: boolean; error?: string } {
-    return createSession(sessionName, windowName, cwd);
+    cwd?: string,
+    appId = "tmux",
+  ): CreateSessionResult {
+    const app = this.apps.get(appId);
+    if (!app || !app.isAvailable()) {
+      return {
+        ok: false,
+        appId,
+        sessionName,
+        created: false,
+        error: `Terminal app '${appId}' is not available`,
+      };
+    }
+    return app.createSession(sessionName, windowName, cwd);
+  }
+
+  detachAll(): void {
+    for (const app of this.apps.values()) {
+      app.detachAll();
+    }
   }
 }
+
+export { TmuxTerminalApp, ShellTerminalApp };

--- a/web/src/lib/components/terminal-view.svelte
+++ b/web/src/lib/components/terminal-view.svelte
@@ -6,6 +6,8 @@
   type FitAddonType = import("@xterm/addon-fit").FitAddon;
 
   interface Props {
+    /** Terminal app id (tmux primary, fallback apps optional) */
+    appId?: string;
     /** Target pane (e.g. "coding:1.0") */
     target: string;
     /** WebSocket to communicate with viber daemon */
@@ -14,7 +16,7 @@
     onClose?: () => void;
   }
 
-  let { target, ws, onClose }: Props = $props();
+  let { appId = "tmux", target, ws, onClose }: Props = $props();
 
   let terminalEl: HTMLDivElement | null = null;
   let term: TerminalType | null = null;
@@ -27,6 +29,7 @@
     try {
       const msg = JSON.parse(event.data);
       if (msg.target !== target) return;
+      if (msg.appId && msg.appId !== appId) return;
 
       switch (msg.type) {
         case "terminal:output":
@@ -50,28 +53,28 @@
   // Send input to viber
   function sendInput(keys: string) {
     if (ws && ws.readyState === WebSocket.OPEN) {
-      ws.send(JSON.stringify({ type: "terminal:input", target, keys }));
+      ws.send(JSON.stringify({ type: "terminal:input", appId, target, keys }));
     }
   }
 
   // Attach to the terminal
   function attach() {
     if (ws && ws.readyState === WebSocket.OPEN) {
-      ws.send(JSON.stringify({ type: "terminal:attach", target }));
+      ws.send(JSON.stringify({ type: "terminal:attach", appId, target }));
     }
   }
 
   // Detach from the terminal
   function detach() {
     if (ws && ws.readyState === WebSocket.OPEN) {
-      ws.send(JSON.stringify({ type: "terminal:detach", target }));
+      ws.send(JSON.stringify({ type: "terminal:detach", appId, target }));
     }
   }
 
   // Inform tmux of our current size
   function sendResize(cols: number, rows: number) {
     if (ws && ws.readyState === WebSocket.OPEN) {
-      ws.send(JSON.stringify({ type: "terminal:resize", target, cols, rows }));
+      ws.send(JSON.stringify({ type: "terminal:resize", appId, target, cols, rows }));
     }
   }
 
@@ -146,7 +149,7 @@
 
 <div class="terminal-container">
   <div class="terminal-header">
-    <span class="terminal-target">{target}</span>
+    <span class="terminal-target">{appId}:{target}</span>
     {#if onClose}
       <button class="terminal-close" onclick={onClose}>×</button>
     {/if}

--- a/web/src/lib/server/hub-client.ts
+++ b/web/src/lib/server/hub-client.ts
@@ -23,15 +23,22 @@ export interface ConnectedViber {
   skills?: ViberSkillInfo[];
 }
 
+export interface HubTaskEvent {
+  at: string;
+  event: unknown;
+}
+
 export interface HubTask {
   id: string;
   viberId: string;
   goal: string;
-  status: "pending" | "running" | "completed" | "error";
+  status: "pending" | "running" | "completed" | "error" | "stopped";
   createdAt: string;
   result?: unknown;
   error?: string;
   eventCount?: number;
+  events?: HubTaskEvent[];
+  partialText?: string;
 }
 
 export const hubClient = {

--- a/web/src/routes/vibers/[id]/+page.svelte
+++ b/web/src/routes/vibers/[id]/+page.svelte
@@ -165,6 +165,20 @@
           const taskRes = await fetch(`/api/tasks/${taskId}`);
           if (!taskRes.ok) return false;
           const task = await taskRes.json();
+          if (task.status === "running" || task.status === "pending") {
+            const streamingText =
+              (task.partialText as string | undefined)?.trim() ||
+              (task.events as Array<{ event?: { message?: string } }> | undefined)
+                ?.slice(-1)
+                ?.map((e) => e?.event?.message)
+                ?.filter(Boolean)
+                ?.join("\n") ||
+              "Processing task...";
+
+            messages = messages.map((m) =>
+              m.id === assistantMessageId ? { ...m, content: streamingText } : m
+            );
+          }
           if (task.status === "completed") {
             const text =
               (task.result?.text as string)?.trim() ||


### PR DESCRIPTION
### Motivation

- Provide real-time visibility into agent execution so the Viber Board can display in-flight text output, tool call milestones, and status phases rather than only final results. 
- Make hub/task APIs surface streaming events and a rolling `partialText` so polling UI and other clients can render live progress.

### Description

- The daemon controller now consumes `streamResult.fullStream` and emits `task:progress` messages for `text-delta`, `tool-call`, `tool-result`, and status phases, and still sends a final `task:completed` with summary (`src/daemon/controller.ts`).
- The hub persists streaming history by adding `events[]` and `partialText` to `Task` and handling incoming `task:progress` events via `handleTaskProgress`, and the task list/detail endpoints now return `events`, `eventCount`, and `partialText` (`src/daemon/hub.ts`).
- The Board-side client types and polling logic were updated so `hub-client` includes `events`/`partialText` in `HubTask`, and the vibers chat page polls `/api/tasks/:id` and displays live `partialText`/recent event messages while a task is `pending`/`running` (`web/src/lib/server/hub-client.ts`, `web/src/routes/vibers/[id]/+page.svelte`).
- Added an integration test `src/daemon/hub.integration.test.ts` that spins up the hub + websocket mock viber, sends `task:progress` events, and verifies `partialText` and `events` are stored and returned; also ran existing terminal integration tests to validate terminal adapter behavior.

### Testing

- Ran type checking with `pnpm typecheck` and it completed successfully.
- Ran integration tests with `pnpm exec vitest run src/daemon/terminal.integration.test.ts src/daemon/hub.integration.test.ts` and all tests passed.
- Started the web dev server with `pnpm dev:web` (server started), and attempted an automated Playwright screenshot; Playwright failed to launch in this container (SIGSEGV), so no screenshot artifact was produced but the change to client polling was validated via tests and local inspection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984af4cba30832e9ee3ba4d7076631b)