### PR TITLE
fix(web): keep docs prev/next pager on same row at responsive sizes

### DIFF
--- a/web/src/routes/docs/+layout.svelte
+++ b/web/src/routes/docs/+layout.svelte
@@ -1286,12 +1286,6 @@
     }
   }
 
-  @media (max-width: 1279px) {
-    .docs-pager {
-      grid-template-columns: minmax(0, 1fr);
-    }
-  }
-
   @media (max-width: 640px) {
     .docs-main-grid {
       padding: 1rem 0.78rem 0;


### PR DESCRIPTION
### Motivation
- Ensure the documentation pager keeps the Previous and Next navigation cards aligned on a single row across responsive sizes so the pager remains visually consistent on small screens.

### Description
- Removed the responsive CSS override in `web/src/routes/docs/+layout.svelte` that forced `.docs-pager` to collapse to a single column below 1280px so the base `grid-template-columns: repeat(2, minmax(0, 1fr))` remains effective.

### Testing
- Ran `pnpm -C web check` which failed due to pre-existing unrelated type/export issues in the web UI (not caused by this CSS change). 
- Launched the docs app with `pnpm -C web dev --host 0.0.0.0 --port 4173` which started successfully. 
- Executed an automated Playwright script to capture a mobile viewport screenshot of a docs page and it completed successfully, confirming the pager displays both cards on one row on a mobile-sized viewport.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984b8c7ac2c832e9923484401a6b8e7)