### PR TITLE
fix(web): disable horizontal scrollbar on homepage

### DIFF
--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -51,7 +51,7 @@
   <title>OpenViber · Agent Runtime Platform</title>
 </svelte:head>
 
-<div class="relative overflow-y-auto h-full">
+<div class="relative h-full overflow-x-hidden overflow-y-auto">
   <div class="pointer-events-none absolute inset-0 -z-10">
     <div
       class="absolute -top-32 left-1/2 size-[40rem] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,hsl(var(--primary)/0.18),transparent_60%)]"


### PR DESCRIPTION
### Motivation
- Prevent the homepage from showing a horizontal scrollbar caused by decorative absolute-positioned background elements by constraining horizontal overflow on the root container.

### Description
- Updated the homepage root wrapper in `web/src/routes/+page.svelte` from `class="relative overflow-y-auto h-full"` to `class="relative h-full overflow-x-hidden overflow-y-auto"` to hide horizontal overflow while preserving vertical scrolling.

### Testing
- Ran `pnpm --dir web check`, which failed due to pre-existing unrelated Svelte/type export errors in `web/src/lib/components/docs/index.ts` and `web/src/lib/components/ui/index.ts`, confirming the change did not introduce new type issues in the checked files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984babb5180832e903455e675f97f7e)