### PR TITLE
feat(daemon): implement intervention loop and structured progress envelopes

### DIFF
--- a/docs/design/multichannel-webux-review.md
+++ b/docs/design/multichannel-webux-review.md
@@ -1,0 +1,115 @@
+# Multichannel & Web UI Implementation Plan
+
+## Goal
+
+Ship the concrete runtime capabilities required for:
+
+1. chat-app-grade streaming UX,
+2. multi-channel consistency,
+3. intervention during in-flight generations, and
+4. replay-friendly progress events for Web UI timelines.
+
+---
+
+## Scope Converted from Review -> Execution
+
+This document is now an implementation plan with completed items marked.
+
+## Phase 1 (Runtime + Protocol Foundations)
+
+### 1. Progress event envelope (implemented)
+
+Implemented in daemon/controller and hub ingestion:
+
+- `eventId`
+- `sequence`
+- `taskId`
+- `conversationId`
+- `createdAt`
+- `model` (optional)
+- nested `event` payload (`text-delta`, `tool-call`, `tool-result`, `status`)
+
+Result:
+
+- Web/Board consumers now have stable ordering metadata and identifiers.
+- Hub normalizes legacy progress payloads for backward compatibility.
+
+### 2. Intervention message modes (implemented)
+
+Implemented `task:message` behavior with three modes:
+
+- `followup` (default): queue next user intervention turn
+- `collect`: append to batch buffer, merged into a single next follow-up turn
+- `steer`: enqueue as priority and interrupt current run to apply intervention
+
+Result:
+
+- Mid-run intervention is now executable in controller runtime.
+- Existing stateless-daemon constraints are preserved by replaying full `messageHistory`.
+
+### 3. Follow-up run loop (implemented)
+
+Controller now keeps per-task runtime state and repeatedly executes until queues are drained:
+
+- initial run
+- dequeue intervention/follow-up message
+- append as user message
+- rerun with full accumulated message history
+
+Result:
+
+- Interventions no longer require manual stop + new submit from operator.
+
+---
+
+## Phase 2 (Web UX Contract)
+
+### 4. Canonical timeline schema (next)
+
+Define a board-facing schema for timeline rendering:
+
+- message id
+- role
+- parts
+- status
+- model provenance
+- usage summary
+
+### 5. Reconnect/replay contract (next)
+
+Add API support for:
+
+- fetch from `sequence > N`
+- periodic state snapshot
+
+---
+
+## Phase 3 (Multi-model UX)
+
+### 6. Per-turn model selection (next)
+
+Extend incoming message contract with per-turn `model` and keep model provenance in each assistant event/message.
+
+### 7. Model routing policy (next)
+
+Add configurable policy layer:
+
+- user pin
+- rule-based selection
+- fallback chain
+
+---
+
+## Acceptance Status
+
+### Done in this change set
+
+- Progress events now carry ordering/envelope metadata.
+- Hub supports both envelope and legacy event shapes.
+- `task:message` supports `steer` / `followup` / `collect` behaviors.
+- Controller can interrupt current run and continue with queued intervention messages.
+
+### Remaining
+
+- Board/web canonical timeline schema and replay endpoint.
+- Per-turn multi-model orchestration and UI controls.


### PR DESCRIPTION
### Motivation

- Convert the previous multichannel/Web UX review into an actionable implementation plan and deliver Phase 1 runtime pieces required for chat-app-grade streaming and intervention. 
- Provide replay-friendly, ordered progress events so Web/Board consumers can render timelines and resume/replay reliably. 
- Allow mid-run user interventions (steer/followup/collect) without requiring manual stop + resubmit workflows.

### Description

- Add a structured `TaskProgressEnvelope` and emit envelope-shaped `task:progress` events from the controller with `eventId`, `sequence`, `taskId`, `conversationId`, `createdAt`, optional `model`, and nested `event` payload. 
- Replace simple AbortController mapping with per-task runtime state `TaskRuntimeState` and implement `executeTask`, `emitTaskProgress`, `dequeueNextMessage`, and a follow-up run loop that re-runs the agent until queued interventions are drained. 
- Implement `task:message` injection modes (`followup`, `collect`, `steer`) in `handleTaskMessage` to queue, collect-batch, or priority-interrupt an in-flight run. 
- Update hub ingestion to `normalizeTaskProgressEvent` so the hub accepts both new envelope-shaped progress events and legacy event shapes, and preserve `partialText` assembly from `text-delta` events. 
- Update integration test and docs by converting the review into an implementation plan document and by asserting envelope ingestion and sequence preservation in `src/daemon/hub.integration.test.ts`.

### Testing

- Ran type checking with `pnpm typecheck` (runs `tsc --noEmit`) and it completed successfully. 
- Ran the hub integration test with `pnpm vitest run src/daemon/hub.integration.test.ts` and the test passed. 
- Verified the daemon emits envelope-shaped `task:progress` messages and the hub normalizes legacy events via the updated integration test which asserts `sequence` presence and `partialText` reconstruction.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984c44122c4832eb3a77cae3a2ea56d)