### PR TITLE
Fix daemon/webui version reporting using package metadata

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -16,8 +16,9 @@ import { program } from "commander";
 import * as os from "os";
 import * as fs from "fs/promises";
 import * as path from "path";
+import { getOpenViberVersion } from "../utils/version";
 
-const VERSION = "1.0.0";
+const VERSION = getOpenViberVersion();
 
 program
   .name("openviber")

--- a/src/daemon/controller.ts
+++ b/src/daemon/controller.ts
@@ -16,6 +16,7 @@ import WebSocket from "ws";
 import type { ViberOptions } from "../core/viber-agent";
 import { runTask } from "./runtime";
 import { TerminalManager } from "./terminal";
+import { getOpenViberVersion } from "../utils/version";
 
 // ==================== Types ====================
 
@@ -201,7 +202,7 @@ export class ViberController extends EventEmitter {
         headers: {
           Authorization: `Bearer ${this.config.token}`,
           "X-Viber-Id": this.config.viberId,
-          "X-Viber-Version": "1.0.0",
+          "X-Viber-Version": getOpenViberVersion(),
         },
       });
 
@@ -245,7 +246,7 @@ export class ViberController extends EventEmitter {
       viber: {
         id: this.config.viberId,
         name: this.config.viberName || this.config.viberId,
-        version: "1.0.0",
+        version: getOpenViberVersion(),
         platform: process.platform,
         capabilities,
           runningTasks: Array.from(this.runningTasks.keys()),

--- a/src/utils/version.test.ts
+++ b/src/utils/version.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { describe, expect, it } from "vitest";
+import { getOpenViberVersion } from "./version";
+
+describe("getOpenViberVersion", () => {
+  it("returns the root package version", () => {
+    const packageJson = JSON.parse(
+      readFileSync(resolve(process.cwd(), "package.json"), "utf8"),
+    ) as { version: string };
+
+    expect(getOpenViberVersion()).toBe(packageJson.version);
+  });
+});

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,0 +1,47 @@
+import { existsSync, readFileSync } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+interface PackageJsonVersion {
+  name?: string;
+  version?: string;
+}
+
+let cachedVersion: string | null = null;
+
+/**
+ * Resolve the OpenViber package version from the nearest package.json.
+ */
+export function getOpenViberVersion(): string {
+  if (cachedVersion) {
+    return cachedVersion;
+  }
+
+  const currentFile = fileURLToPath(import.meta.url);
+  let currentDir = path.dirname(currentFile);
+
+  while (true) {
+    const packageJsonPath = path.join(currentDir, "package.json");
+    if (existsSync(packageJsonPath)) {
+      try {
+        const raw = readFileSync(packageJsonPath, "utf8");
+        const parsed = JSON.parse(raw) as PackageJsonVersion;
+        if (parsed.version && (!parsed.name || parsed.name === "openviber")) {
+          cachedVersion = parsed.version;
+          return cachedVersion;
+        }
+      } catch {
+        // Keep walking up the directory tree.
+      }
+    }
+
+    const parent = path.dirname(currentDir);
+    if (parent === currentDir) {
+      break;
+    }
+    currentDir = parent;
+  }
+
+  cachedVersion = "0.0.0";
+  return cachedVersion;
+}


### PR DESCRIPTION
### Motivation

- The daemon and CLI were reporting a hardcoded `1.0.0` version which prevented the hub/web UI from reliably detecting runtime versions for deployment/update flows.

### Description

- Add a shared resolver `getOpenViberVersion()` in `src/utils/version.ts` that walks up to the nearest `package.json`, caches the result, and falls back to `0.0.0` when not found.
- Use the resolver for the CLI `program.version(...)` in `src/cli/index.ts` so `openviber --version` reflects the package version.
- Replace hardcoded daemon metadata with the resolver in `src/daemon/controller.ts` for the `X-Viber-Version` WebSocket header and the `connected` payload `viber.version` so the hub/web UI sees the real runtime version.
- Add a unit test `src/utils/version.test.ts` that verifies the resolver matches the repository `package.json` version.

### Testing

- Ran `pnpm test:run src/utils/version.test.ts src/daemon/hub.integration.test.ts` and both tests passed.
- Ran `pnpm typecheck` (TypeScript `tsc --noEmit`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985cf38b490832e94bed3911f1b4e7b)