### PR TITLE
docs: align docs with implemented channels, skills, and tools

### DIFF
--- a/docs/concepts/skills.md
+++ b/docs/concepts/skills.md
@@ -56,7 +56,9 @@ This "atomic" approach keeps detection and recovery bundled together.
 
 | Skill | Purpose |
 |-------|---------|
-| **antigravity** | Monitor and heal IDE agent errors |
+| **antigravity** | Monitor and heal Antigravity IDE agent errors |
+| **cursor-agent** | Run Cursor CLI agent workflows through tmux-backed automation |
+| **tmux** | Execute TTY-dependent commands and manage persistent terminal sessions |
 
 ## Creating Custom Skills
 

--- a/docs/concepts/tools.md
+++ b/docs/concepts/tools.md
@@ -17,13 +17,17 @@ Think of tools like apps on your phone — each one does something specific, and
 
 OpenViber comes with several tools ready to use:
 
+For terminal automation, OpenViber uses the **tmux skill** (`tmux`, `cursor-agent`) rather than a standalone terminal tool.
+
 | Tool | What It Does |
 |------|--------------|
 | **File** | Read, write, create, and delete files |
-| **Terminal** | Run shell commands and scripts |
-| **Browser** | Navigate web pages, click, type, extract content |
 | **Search** | Find information online |
+| **Web** | Fetch, parse, and crawl web content |
+| **Browser** | Navigate web pages, click, type, and extract content |
 | **Desktop** | Interact with desktop applications |
+| **Schedule** | Create, list, and manage recurring job schedules |
+| **Notify** | Send desktop notifications for important events |
 
 ## How Agents Use Tools
 

--- a/docs/getting-started/onboarding.md
+++ b/docs/getting-started/onboarding.md
@@ -36,7 +36,9 @@ Get a key at [openrouter.ai/keys](https://openrouter.ai/keys)
 openviber start
 ```
 
-Open http://localhost:6006 to access the Viber Board.
+For terminal-first usage, keep interacting in your shell.
+
+For the Viber Board web UI, run `pnpm dev:web` in a second terminal and open http://localhost:6006.
 
 ## Alternative: Global Install
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -33,7 +33,18 @@ Start the full viber for back-and-forth conversations:
 npx openviber start
 ```
 
-Open http://localhost:6006 and try:
+Then either:
+
+- Keep chatting in your terminal, or
+- Start the web app (`pnpm dev:web`) and open http://localhost:6006.
+
+In local development, the default ports are:
+
+- Hub: `6007`
+- Web UI: `6006`
+- Local WS: `6008`
+
+Try this prompt:
 
 > "Find all the TODOs in this project, prioritize them, and create a task list"
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -26,7 +26,7 @@ Open the browser-based interface to chat with your viber:
 
 ```bash
 npx openviber start
-# Open http://localhost:5173
+# Start the web UI (`pnpm dev:web`) and open http://localhost:6006
 ```
 
 ### 2. Command Line
@@ -46,7 +46,7 @@ openviber run jobs/morning-standup.yaml
 Connect to DingTalk or WeCom for team collaboration:
 
 ```bash
-openviber start --channel dingtalk --token YOUR_TOKEN
+openviber gateway
 ```
 
 ## Key Concepts
@@ -55,7 +55,7 @@ openviber start --channel dingtalk --token YOUR_TOKEN
 |---------|------------|
 | **Viber** | Your machine + OpenViber = an AI teammate |
 | **Agent** | The AI that reasons, plans, and executes tasks |
-| **Tools** | Actions the agent can take (file, terminal, browser) |
+| **Tools** | Actions the agent can take (file, search, web, browser, desktop, etc.) |
 | **Skills** | Domain knowledge injected as instructions |
 | **Jobs** | Scheduled tasks defined in YAML |
 


### PR DESCRIPTION
### Motivation
- Fix documentation mismatches where docs referenced unimplemented or differently-implemented features (enterprise channels, terminal tooling, and available skills/tools). 
- Reduce confusion about how to start the web UI and which local ports are used for development. 

### Description
- Update `docs/concepts/skills.md` to list the actual built-in skills (`antigravity`, `cursor-agent`, `tmux`) and provide concise purposes for each. 
- Update `docs/concepts/tools.md` to reflect the implemented tool set (`file`, `search`, `web`, `browser`, `desktop`, `schedule`, `notify`) and add a note that terminal automation is handled via the `tmux`/`cursor-agent` skills rather than a standalone Terminal tool. 
- Update `docs/introduction.md` to make web UI startup explicit (`pnpm dev:web` and `http://localhost:6006`) and replace the outdated `--channel` example with the `openviber gateway` entrypoint for enterprise channels. 
- Update `docs/getting-started/onboarding.md` to clarify terminal-first usage and explicit steps to launch the Viber Board web UI. 

### Testing
- Ran type checking with `pnpm typecheck` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985f972c284832e82941e8d2a7e7dc6)