### PR TITLE
fix(web): resolve svelte-check errors for issue #49

### DIFF
--- a/web/drizzle/schema.ts
+++ b/web/drizzle/schema.ts
@@ -64,7 +64,3 @@ export type Task = typeof tasks.$inferSelect;
 export type NewTask = typeof tasks.$inferInsert;
 export type Message = typeof messages.$inferSelect;
 export type NewMessage = typeof messages.$inferInsert;
-export type User = typeof users.$inferSelect;
-export type NewUser = typeof users.$inferInsert;
-export type Session = typeof sessions.$inferSelect;
-export type NewSession = typeof sessions.$inferInsert;

--- a/web/src/lib/components/docs/index.ts
+++ b/web/src/lib/components/docs/index.ts
@@ -1,4 +1,4 @@
-export { default as Aside } from "./aside.svelte";
-export { default as Card } from "./card.svelte";
+export { default as Aside } from "./Aside.svelte";
+export { default as Card } from "./Card.svelte";
 export { default as CardGrid } from "./card-grid.svelte";
 export { default as LinkCard } from "./link-card.svelte";

--- a/web/src/lib/components/ui/index.ts
+++ b/web/src/lib/components/ui/index.ts
@@ -18,20 +18,10 @@ export {
   DropdownMenuTrigger,
 } from "./dropdown-menu";
 
-// Sidebar
-export * from "./sidebar";
-
-// Separator
-export * from "./separator";
-
-// Skeleton
-export * from "./skeleton";
-
-// Sheet
-export * from "./sheet";
-
-// Tooltip
-export * from "./tooltip";
-
-// Resizable
-export * from "./resizable";
+// Namespace exports to avoid symbol collisions across component modules
+export * as Sidebar from "./sidebar";
+export * as Separator from "./separator";
+export * as Skeleton from "./skeleton";
+export * as Sheet from "./sheet";
+export * as Tooltip from "./tooltip";
+export * as Resizable from "./resizable";


### PR DESCRIPTION
### Motivation
- svelte-check and TypeScript diagnostics flagged module resolution and duplicate export errors originating from the web UI barrel files and stale type exports in the Drizzle schema.
- These errors break CI and local `pnpm test` runs (the `scripts/web-check.test.ts` svelte-check step). 

### Description
- Updated `web/src/lib/components/docs/index.ts` to use the correct case-sensitive filenames for exports (`Aside.svelte`, `Card.svelte`) to fix module-not-found errors on case-sensitive filesystems. 
- Reworked `web/src/lib/components/ui/index.ts` to export collision-prone component modules as namespaces (`export * as Sidebar from "./sidebar"` etc.) to avoid duplicate symbol export errors reported by svelte-check. 
- Removed stale `users`/`sessions` type exports from `web/drizzle/schema.ts` that referenced undefined tables and caused type errors. 
- Changes touch `web/src/lib/components/docs/index.ts`, `web/src/lib/components/ui/index.ts`, and `web/drizzle/schema.ts`.

### Testing
- Ran the full test suite with `pnpm test`, which completed successfully and reported all tests passing (including `scripts/web-check.test.ts` that runs `svelte-check`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986954fcc74832e8f643c17e162c8f7)