### PR TITLE
fix(runtime): align daemon fallback default agent config with default.yaml

### DIFF
--- a/src/daemon/runtime.ts
+++ b/src/daemon/runtime.ts
@@ -72,13 +72,13 @@ export async function loadAgentConfig(
       name: "Default",
       description: "General-purpose assistant with local skills.",
       provider: "openrouter",
-      model: "deepseek/deepseek-chat",
+      model: "openai/gpt-4o",
       temperature: 0.7,
       maxTokens: 4096,
       systemPrompt:
         "You are a helpful AI assistant. You help users accomplish their tasks efficiently and effectively. Be concise, accurate, and helpful.",
       tools: [],
-      skills: ["tmux", "cursor-agent"],
+      skills: ["tmux"],
     } as AgentConfig;
   }
 


### PR DESCRIPTION
### Motivation
- Align the daemon's in-code fallback agent configuration with the file-based default to avoid inconsistent behavior depending on which config path is used.
- The built-in `default.yaml` uses `openai/gpt-4o` and only the `tmux` skill, while the runtime fallback previously used different values, causing divergence.

### Description
- Updated the fallback `model` in `src/daemon/runtime.ts` from `deepseek/deepseek-chat` to `openai/gpt-4o`.
- Updated the fallback `skills` in `src/daemon/runtime.ts` from `["tmux", "cursor-agent"]` to `["tmux"]`.
- These changes make the in-code fallback match `src/data/defaults/agents/default.yaml`.

### Testing
- Ran `pnpm -s typecheck`, which completed successfully.
- Ran `pnpm -s vitest run src/daemon/task-lifecycle.e2e.test.ts`, which passed (1 test file, 2 tests passed, 3 skipped).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698694f58240832e97782fb54b7717f3)