### PR TITLE
fix(web): add UI and API for agent tool/skill config (#46)

### DIFF
--- a/web/src/routes/api/vibers/[id]/config/+server.ts
+++ b/web/src/routes/api/vibers/[id]/config/+server.ts
@@ -1,0 +1,108 @@
+import { json } from "@sveltejs/kit";
+import type { RequestHandler } from "./$types";
+import { env } from "$env/dynamic/private";
+import { homedir } from "os";
+import path from "path";
+import fs from "fs/promises";
+import * as yaml from "yaml";
+
+interface AgentConfig {
+  name?: string;
+  tools?: string[];
+  skills?: string[];
+  [key: string]: unknown;
+}
+
+const DEFAULT_TOOLS = [
+  "file",
+  "terminal",
+  "browser",
+  "search",
+  "fetch",
+  "git",
+  "schedule",
+] as const;
+
+function getOpenViberDir(): string {
+  return env.OPENVIBER_DATA_DIR || path.join(homedir(), ".openviber");
+}
+
+async function resolveConfigPath(viberId: string): Promise<string> {
+  const agentsDir = path.join(getOpenViberDir(), "agents");
+  const candidates = [
+    path.join(agentsDir, `${viberId}.yaml`),
+    path.join(agentsDir, `${viberId}.yml`),
+    path.join(agentsDir, "default.yaml"),
+    path.join(agentsDir, "default.yml"),
+  ];
+
+  for (const candidate of candidates) {
+    try {
+      await fs.access(candidate);
+      return candidate;
+    } catch {
+      // Continue searching candidates.
+    }
+  }
+
+  throw new Error(
+    "Agent config not found. Run `openviber onboard` to create ~/.openviber/agents/default.yaml.",
+  );
+}
+
+async function loadConfig(viberId: string): Promise<{ config: AgentConfig; configPath: string }> {
+  const configPath = await resolveConfigPath(viberId);
+  const content = await fs.readFile(configPath, "utf8");
+  const config = (yaml.parse(content) ?? {}) as AgentConfig;
+  return { config, configPath };
+}
+
+export const GET: RequestHandler = async ({ params }) => {
+  try {
+    const { config, configPath } = await loadConfig(params.id);
+    const toolOptions = Array.from(
+      new Set([...(config.tools ?? []), ...DEFAULT_TOOLS]),
+    ).sort((a, b) => a.localeCompare(b));
+
+    return json({
+      configFile: path.basename(configPath),
+      tools: config.tools ?? [],
+      skills: config.skills ?? [],
+      toolOptions,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to load config";
+    return json({ error: message }, { status: 404 });
+  }
+};
+
+export const PUT: RequestHandler = async ({ params, request }) => {
+  try {
+    const body = (await request.json()) as { tools?: string[]; skills?: string[] };
+    const { config, configPath } = await loadConfig(params.id);
+
+    const normalize = (items: string[] | undefined) =>
+      Array.from(
+        new Set(
+          (items ?? [])
+            .map((item) => item.trim())
+            .filter((item) => item.length > 0),
+        ),
+      );
+
+    config.tools = normalize(body.tools);
+    config.skills = normalize(body.skills);
+
+    await fs.writeFile(configPath, yaml.stringify(config), "utf8");
+
+    return json({
+      ok: true,
+      configFile: path.basename(configPath),
+      tools: config.tools,
+      skills: config.skills,
+    });
+  } catch (error) {
+    console.error("[Viber Config API] Failed to update config:", error);
+    return json({ error: "Failed to update config" }, { status: 500 });
+  }
+};


### PR DESCRIPTION
### Motivation

- Users currently must edit YAML under `~/.openviber/agents` to control an agent's tools and skills, which is not discoverable or convenient. This change adds a web UI and server endpoint so the Viber Board can manage those settings. 

### Description

- Add a new server endpoint `GET/PUT /api/vibers/[id]/config` that resolves agent YAML in `~/.openviber/agents` (tries `<viberId>.yaml/.yml` then `default.yaml/.yml`), returns `tools`, `skills`, and `toolOptions`, and normalizes/persists updates back to the YAML file (`web/src/routes/api/vibers/[id]/config/+server.ts`).
- Implement an Agent config panel in the Viber chat page to load config, toggle enabled tools from a computed `toolOptions` list, edit skills as comma-separated values, and save changes to the server (`web/src/routes/vibers/[id]/+page.svelte`).
- Provide UX for first-time setups with guidance to run `openviber onboard` when no agent config is found, and surface the current config filename in the UI.
- Include a default tool set used to populate UI options and ensure reasonable defaults when a config omits `tools`.

### Testing

- Ran `pnpm -C web build` which completed successfully and included the new endpoint in the production bundle. (Succeeded)
- Ran `pnpm -C web check` which failed due to pre-existing unrelated type / barrel export issues in `web/src/lib/components/docs` and `web/src/lib/components/ui` and drizzle schema types, not caused by these changes. (Failed)
- Started the dev server and captured a Playwright screenshot of the updated Viber page to validate the UI rendering (screenshot artifact produced). (Succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69869574d578832ebbb77ee60626b468)