### PR TITLE
fix(web): resolve svelte-check failures (issue #35)

### DIFF
--- a/web/drizzle/schema.ts
+++ b/web/drizzle/schema.ts
@@ -54,7 +54,6 @@ export const messages = sqliteTable("messages", {
 });
 
 
-
 // Export types
 export type Viber = typeof vibers.$inferSelect;
 export type NewViber = typeof vibers.$inferInsert;
@@ -64,7 +63,3 @@ export type Task = typeof tasks.$inferSelect;
 export type NewTask = typeof tasks.$inferInsert;
 export type Message = typeof messages.$inferSelect;
 export type NewMessage = typeof messages.$inferInsert;
-export type User = typeof users.$inferSelect;
-export type NewUser = typeof users.$inferInsert;
-export type Session = typeof sessions.$inferSelect;
-export type NewSession = typeof sessions.$inferInsert;

--- a/web/src/lib/components/docs/index.ts
+++ b/web/src/lib/components/docs/index.ts
@@ -1,4 +1,4 @@
-export { default as Aside } from "./aside.svelte";
-export { default as Card } from "./card.svelte";
+export { default as Aside } from "./Aside.svelte";
+export { default as Card } from "./Card.svelte";
 export { default as CardGrid } from "./card-grid.svelte";
 export { default as LinkCard } from "./link-card.svelte";

--- a/web/src/lib/components/ui/index.ts
+++ b/web/src/lib/components/ui/index.ts
@@ -22,16 +22,33 @@ export {
 export * from "./sidebar";
 
 // Separator
-export * from "./separator";
+export { Separator } from "./separator";
 
 // Skeleton
-export * from "./skeleton";
+export { Skeleton } from "./skeleton";
 
 // Sheet
-export * from "./sheet";
+export {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetOverlay,
+  SheetPortal,
+  SheetTitle,
+  SheetTrigger,
+} from "./sheet";
 
 // Tooltip
-export * from "./tooltip";
+export {
+  Tooltip,
+  TooltipContent,
+  TooltipPortal,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./tooltip";
 
 // Resizable
 export * from "./resizable";


### PR DESCRIPTION
### Motivation
- svelte-check and TypeScript diagnostics were failing due to incorrect component import casing and ambiguous barrel exports in the web UI, plus stale Drizzle type exports referencing undefined tables.

### Description
- Fixed docs barrel to import the actual case-sensitive component filenames by changing `./aside.svelte`/`./card.svelte` to `./Aside.svelte`/`./Card.svelte` in `web/src/lib/components/docs/index.ts`.
- Replaced broad `export *` re-exports that caused name collisions with explicit named exports for `separator`, `skeleton`, `sheet`, and `tooltip` in `web/src/lib/components/ui/index.ts` to avoid duplicate symbol exports.
- Removed stale `User`/`Session` type exports in `web/drizzle/schema.ts` that referenced non-existent `users`/`sessions` tables to eliminate TypeScript errors.

### Testing
- Ran the full test suite with `pnpm test`, which passed (`16 passed | 4 skipped`).
- Ran type-checking with `pnpm tsc --noEmit`, which completed with no errors.
- The web Svelte check (covered by `scripts/web-check.test.ts`) also passes as part of `pnpm test`, resolving the previous regression reported by `svelte-check`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986965fe664832e814808ca37bb01c0)