### PR TITLE
Improve Codex-like tool-call UX during task execution (fix #29, #48)

### DIFF
--- a/src/daemon/controller.ts
+++ b/src/daemon/controller.ts
@@ -479,12 +479,16 @@ export class ViberController extends EventEmitter {
             kind: "tool-call",
             toolName: part.toolName,
             toolCallId: part.toolCallId,
+            args: part.args,
           });
           break;
         case "tool-result":
           this.emitTaskProgress(runtime, {
             kind: "tool-result",
             toolCallId: part.toolCallId,
+            toolName: part.toolName,
+            result: part.result,
+            isError: part.isError,
           });
           break;
         case "error":

--- a/web/src/routes/vibers/[id]/+page.svelte
+++ b/web/src/routes/vibers/[id]/+page.svelte
@@ -49,6 +49,67 @@
     createdAt: Date;
   }
 
+  interface TaskProgressEnvelope {
+    event?: Record<string, unknown>;
+  }
+
+  interface TaskEventEntry {
+    event?: TaskProgressEnvelope;
+  }
+
+  function toToolLabel(value: unknown): string {
+    if (typeof value !== "string" || !value.trim()) return "tool";
+    return value.trim();
+  }
+
+  function stringifyToolDetails(value: unknown): string {
+    if (value == null) return "";
+    if (typeof value === "string") return value;
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch {
+      return String(value);
+    }
+  }
+
+  function buildProgressText(task: {
+    partialText?: string;
+    events?: TaskEventEntry[];
+  }): string {
+    const progressLines: string[] = [];
+
+    for (const entry of task.events ?? []) {
+      const payload = entry?.event?.event;
+      if (!payload || typeof payload !== "object") continue;
+      const data = payload as Record<string, unknown>;
+
+      const kind = data.kind;
+      if (kind === "tool-call") {
+        const toolName = toToolLabel(data.toolName);
+        progressLines.push(`🛠️ Calling ${toolName}...`);
+        continue;
+      }
+
+      if (kind === "tool-result") {
+        const toolName = toToolLabel(data.toolName);
+        progressLines.push(`✅ ${toolName} finished`);
+
+        const result = stringifyToolDetails(data.result);
+        if (result) {
+          const preview = result.length > 400 ? `${result.slice(0, 400)}…` : result;
+          progressLines.push(`Result: ${preview}`);
+        }
+      }
+    }
+
+    const text = typeof task.partialText === "string" ? task.partialText.trim() : "";
+    if (text) {
+      progressLines.push(text);
+    }
+
+    return progressLines.length > 0 ? progressLines.join("\n") : "Processing task...";
+  }
+
   let viber = $state<Viber | null>(null);
   let messages = $state<Message[]>([]);
   let loading = $state(true);
@@ -182,18 +243,10 @@
           if (!taskRes.ok) return false;
           const task = await taskRes.json();
           if (task.status === "running" || task.status === "pending") {
-            const streamingText =
-              (task.partialText as string | undefined)?.trim() ||
-              (
-                task.events as
-                  | Array<{ event?: { message?: string } }>
-                  | undefined
-              )
-                ?.slice(-1)
-                ?.map((e) => e?.event?.message)
-                ?.filter(Boolean)
-                ?.join("\n") ||
-              "Processing task...";
+            const streamingText = buildProgressText(task as {
+              partialText?: string;
+              events?: TaskEventEntry[];
+            });
 
             messages = messages.map((m) =>
               m.id === assistantMessageId


### PR DESCRIPTION
### Motivation
- Surface in-flight tool activity and results in the chat UI so users see Codex-like tool-call feedback while a task is running.
- Ensure the hub/daemon emits structured tool metadata so the board and chat can render meaningful intermediate updates.
- Replace the fragile legacy polling that looked for `event.message` with a structured progress renderer that composes tool events and partial model text.

### Description
- Emit richer progress envelopes from the daemon by including `args` on `tool-call` events and `toolName`, `result`, and `isError` on `tool-result` events in `src/daemon/controller.ts`.
- Add typed helper logic and parsing on the chat page at `web/src/routes/vibers/[id]/+page.svelte`, including `TaskProgressEnvelope`/`TaskEventEntry`, `toToolLabel`, `stringifyToolDetails`, and `buildProgressText` to render Codex-like lines such as `🛠️ Calling <tool>...` and `✅ <tool> finished` with short previews.
- Replace the previous `task.events[*].event.message` fallback with a call to `buildProgressText(...)` during polling so running/pending tasks surface tool-call and partial text updates in real time.

### Testing
- Ran type check with `pnpm tsc --noEmit` which completed successfully.
- Executed the test suite with `pnpm test` and all tests passed (unit and integration tests ran successfully).
- Launched the web dev server (`pnpm dev`) and captured a manual UI smoke screenshot of `/vibers/test` to validate the live tool-call UX rendering.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986992781b0832e80260b21b17e8399)