### PR TITLE
feat(core): implement working-mode approval flow for tool execution (#44)

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -33,5 +33,15 @@ export interface AgentConfig {
   frequencyPenalty?: number;
   presencePenalty?: number;
   promptFile?: string; // Optional prompt file path
+  mode?: "always_ask" | "agent_decides" | "always_execute";
+  workingMode?:
+    | "always_ask"
+    | "agent_decides"
+    | "always_execute"
+    | "always-ask"
+    | "agent-decides"
+    | "always-execute";
+  require_approval?: string[];
+  requireApproval?: string[];
   [key: string]: any; // Allow additional properties
 }

--- a/src/core/working-mode.test.ts
+++ b/src/core/working-mode.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyWorkingModeToTools,
+  resolveRequireApprovalTools,
+  resolveWorkingMode,
+} from "./working-mode";
+import type { AgentConfig } from "./config";
+
+describe("working-mode", () => {
+  it("resolves default and alias working modes", () => {
+    expect(resolveWorkingMode({} as AgentConfig)).toBe("agent_decides");
+    expect(resolveWorkingMode({ mode: "always_ask" } as AgentConfig)).toBe(
+      "always_ask"
+    );
+    expect(
+      resolveWorkingMode({ workingMode: "always-execute" } as AgentConfig)
+    ).toBe("always_execute");
+  });
+
+  it("resolves require approval tools from both config key styles", () => {
+    expect(
+      Array.from(
+        resolveRequireApprovalTools({
+          require_approval: ["create_file"],
+        } as AgentConfig)
+      )
+    ).toEqual(["create_file"]);
+
+    expect(
+      Array.from(
+        resolveRequireApprovalTools({
+          requireApproval: ["delete_file"],
+        } as AgentConfig)
+      )
+    ).toEqual(["delete_file"]);
+  });
+
+  it("blocks tools in always_ask mode without metadata approval", async () => {
+    const tools = {
+      create_file: {
+        description: "create",
+        inputSchema: {},
+        execute: async () => "ok",
+      },
+    };
+
+    const wrapped = applyWorkingModeToTools(tools, {
+      mode: "always_ask",
+      requireApproval: new Set(),
+      metadata: {},
+    });
+
+    await expect(wrapped!.create_file.execute({})).rejects.toThrow(
+      /Approval required/
+    );
+  });
+
+  it("allows approved tools in always_ask mode", async () => {
+    const tools = {
+      create_file: {
+        description: "create",
+        inputSchema: {},
+        execute: async () => "ok",
+      },
+    };
+
+    const wrapped = applyWorkingModeToTools(tools, {
+      mode: "always_ask",
+      requireApproval: new Set(),
+      metadata: { approvedTools: ["create_file"] },
+    });
+
+    await expect(wrapped!.create_file.execute({})).resolves.toBe("ok");
+  });
+
+  it("blocks only configured tools in agent_decides mode", async () => {
+    const tools = {
+      read_file: {
+        description: "read",
+        inputSchema: {},
+        execute: async () => "read",
+      },
+      delete_file: {
+        description: "delete",
+        inputSchema: {},
+        execute: async () => "delete",
+      },
+    };
+
+    const wrapped = applyWorkingModeToTools(tools, {
+      mode: "agent_decides",
+      requireApproval: new Set(["delete_file"]),
+      metadata: {},
+    });
+
+    await expect(wrapped!.read_file.execute({})).resolves.toBe("read");
+    await expect(wrapped!.delete_file.execute({})).rejects.toThrow(
+      /Approval required/
+    );
+  });
+});

--- a/src/core/working-mode.ts
+++ b/src/core/working-mode.ts
@@ -1,0 +1,103 @@
+import type { AgentConfig } from "./config";
+import type { CoreTool } from "./tool";
+
+export type WorkingMode = "always_ask" | "agent_decides" | "always_execute";
+
+const MODE_ALIASES: Record<string, WorkingMode> = {
+  "always_ask": "always_ask",
+  "always-ask": "always_ask",
+  "agent_decides": "agent_decides",
+  "agent-decides": "agent_decides",
+  "always_execute": "always_execute",
+  "always-execute": "always_execute",
+};
+
+/**
+ * Resolve the configured working mode from supported config keys.
+ */
+export function resolveWorkingMode(config: AgentConfig): WorkingMode {
+  const rawMode = config.mode ?? config.workingMode;
+
+  if (typeof rawMode !== "string") {
+    return "agent_decides";
+  }
+
+  return MODE_ALIASES[rawMode] ?? "agent_decides";
+}
+
+/**
+ * Resolve tools that require explicit approval in agent_decides mode.
+ */
+export function resolveRequireApprovalTools(config: AgentConfig): Set<string> {
+  const configured = config.require_approval ?? config.requireApproval;
+  if (!Array.isArray(configured)) {
+    return new Set<string>();
+  }
+
+  return new Set(
+    configured.filter((item): item is string => typeof item === "string")
+  );
+}
+
+/**
+ * Check whether the current request metadata includes approval for a tool.
+ */
+export function hasToolApproval(
+  metadata: Record<string, unknown> | undefined,
+  toolName: string
+): boolean {
+  const approvedTools = metadata?.approvedTools;
+  if (!Array.isArray(approvedTools)) {
+    return false;
+  }
+
+  return approvedTools.includes(toolName);
+}
+
+/**
+ * Wrap tools with working-mode approval checks.
+ */
+export function applyWorkingModeToTools(
+  tools: Record<string, CoreTool> | undefined,
+  options: {
+    mode: WorkingMode;
+    requireApproval: Set<string>;
+    metadata?: Record<string, unknown>;
+  }
+): Record<string, CoreTool> | undefined {
+  if (!tools) return undefined;
+
+  const { mode, requireApproval, metadata } = options;
+
+  if (mode === "always_execute") {
+    return tools;
+  }
+
+  return Object.fromEntries(
+    Object.entries(tools).map(([toolName, tool]) => {
+      const shouldAsk =
+        mode === "always_ask" ||
+        (mode === "agent_decides" && requireApproval.has(toolName));
+
+      if (!shouldAsk) {
+        return [toolName, tool];
+      }
+
+      return [
+        toolName,
+        {
+          ...tool,
+          execute: async (args: unknown, context?: unknown) => {
+            if (hasToolApproval(metadata, toolName)) {
+              return tool.execute(args, context);
+            }
+
+            throw new Error(
+              `Approval required for tool '${toolName}'. Ask the user for confirmation and retry with metadata.approvedTools including '${toolName}'.`
+            );
+          },
+        } satisfies CoreTool,
+      ];
+    })
+  );
+}


### PR DESCRIPTION
### Motivation
- Documentation describes three working modes (Always Ask / Agent Decides / Always Execute) but the runtime did not enforce them, leaving a gap in safety and expected behavior.
- Provide a simple, config-driven approval mechanism so tools can be blocked or allowed based on agent working mode and request metadata.

### Description
- Add a new module `src/core/working-mode.ts` that provides `resolveWorkingMode()`, `resolveRequireApprovalTools()`, `applyWorkingModeToTools()` and helper functions to parse mode/approval config and wrap tool execution with approval checks.
- Wire working-mode enforcement into the agent runtime by resolving mode/approval in the `Agent` constructor and applying `applyWorkingModeToTools()` from `Agent.getTools()` (affecting `streamText`/`generateText` and debug paths).  
- Extend `AgentConfig` typing in `src/core/config.ts` to support `mode`/`workingMode` and `require_approval` / `requireApproval` keys (aliases supported for kebab/camel/snake cases).  
- Add unit tests in `src/core/working-mode.test.ts` to cover mode resolution, approval-list parsing, and enforcement behavior for `always_ask` and `agent_decides`.

### Testing
- Ran targeted tests with `pnpm test -- --run src/core/working-mode.test.ts src/core/provider.test.ts` and they passed (working-mode behavior verified). 
- Ran type check with `pnpm tsc --noEmit` and the project type-check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69869f19e7cc832e94cc45fb705389ba)