### PR TITLE
Add opt-in long-running Codex integration tests and harden codex-cli tool

### DIFF
--- a/src/skills/codex-cli.integration.test.ts
+++ b/src/skills/codex-cli.integration.test.ts
@@ -87,6 +87,7 @@ describe("codex-cli skill integration", () => {
     const tool = tools.codex_run;
     expect(tool.inputSchema).toBeDefined();
     expect(tool.execute).toBeTypeOf("function");
+
     // Zod schema: prompt is required, others optional
     const schema = tool.inputSchema as {
       shape?: Record<string, unknown>;
@@ -96,28 +97,66 @@ describe("codex-cli skill integration", () => {
     expect(shape).toBeDefined();
     expect(shape?.prompt).toBeDefined();
     expect(shape?.approvalMode).toBeDefined();
+    expect(shape?.waitSeconds).toBeDefined();
   });
 
-  const runLive = process.env.OPENVIBER_RUN_LIVE_CLI_TESTS === "1";
-  const maybeIt = runLive ? it : it.skip;
+  const runLiveBasic = process.env.OPENVIBER_RUN_LIVE_CLI_TESTS === "1";
+  const runLiveComplex = process.env.OPENVIBER_RUN_LIVE_CLI_COMPLEX_TESTS === "1";
+  const maybeBasic = runLiveBasic ? it : it.skip;
+  const maybeComplex = runLiveComplex ? it : it.skip;
 
-  maybeIt("codex_run execute returns shape { ok, output?, error?, cwd } (live codex)", async () => {
+  maybeBasic("codex_run execute returns rich shape (live codex basic)", async () => {
     const tools = getCodexCliTools();
     const run = tools.codex_run.execute;
 
     const result = await run({
       prompt: "Reply with exactly: INTEGRATION_TEST_OK",
-      waitSeconds: 10,
+      waitSeconds: 30,
       approvalMode: "suggest",
     });
 
     expect(result).toHaveProperty("ok");
     expect(typeof result.ok).toBe("boolean");
     expect(result).toHaveProperty("cwd");
+    expect(result).toHaveProperty("summary");
+    expect(result).toHaveProperty("stdoutTail");
+    expect(result).toHaveProperty("stderrTail");
+    expect(result).toHaveProperty("output");
+
     if (result.ok) {
-      expect(result).toHaveProperty("output");
+      expect(result.output.length).toBeGreaterThan(0);
     } else {
       expect(result).toHaveProperty("error");
     }
-  }, 30_000);
+  }, 60_000);
+
+  maybeComplex(
+    "codex_run handles longer complex repository analysis flows (live codex complex)",
+    async () => {
+      const tools = getCodexCliTools();
+      const run = tools.codex_run.execute;
+
+      const result = await run({
+        prompt:
+          "Analyze this repository and produce a concise implementation plan to improve robustness of src/skills/codex-cli/index.ts. Include: risks, edge cases, and 3 prioritized actions with file paths.",
+        cwd: process.cwd(),
+        waitSeconds: 420,
+        approvalMode: "suggest",
+      });
+
+      expect(result).toHaveProperty("ok");
+      expect(result).toHaveProperty("summary");
+      expect(result.summary).toContain("approvalMode=suggest");
+      expect(result.summary).toContain("status=");
+      expect(result.summary).toContain("exitCode=");
+      expect(result).toHaveProperty("stdoutTail");
+      expect(result).toHaveProperty("stderrTail");
+
+      // Complex run may pass or fail depending on environment/login, but must be actionable.
+      if (!result.ok) {
+        expect(result.error).toBeDefined();
+      }
+    },
+    480_000,
+  );
 });

--- a/src/skills/codex-cli/index.ts
+++ b/src/skills/codex-cli/index.ts
@@ -1,14 +1,34 @@
 import { z } from "zod";
 import { spawn } from "child_process";
+import * as fs from "fs";
 import * as path from "path";
 
 const MAX_CAPTURE_CHARS = 12000;
+const MIN_WAIT_SECONDS = 10;
+const DEFAULT_WAIT_SECONDS = 90;
+const DEFAULT_TAIL_LINES = 80;
 
 /**
  * codex_run compatibility modes.
  * These keep the existing skill API stable while mapping to current Codex CLI flags.
  */
 type ApprovalMode = "full-auto" | "auto-edit" | "suggest";
+
+type CodexRunResult = {
+  ok: boolean;
+  cwd: string;
+  approvalMode: ApprovalMode;
+  model?: string;
+  command?: string;
+  exitCode?: number | null;
+  timedOut?: boolean;
+  output: string;
+  stdoutTail: string;
+  stderrTail: string;
+  stderr?: string;
+  error?: string;
+  summary: string;
+};
 
 /**
  * Limit output size so tool results do not explode token usage.
@@ -21,6 +41,60 @@ function truncateOutput(raw: string): string {
   const tail = raw.slice(-Math.floor(MAX_CAPTURE_CHARS / 2));
   const hidden = raw.length - head.length - tail.length;
   return `${head}\n...[truncated ${hidden} chars]...\n${tail}`;
+}
+
+/**
+ * Convert full output into a short line-based tail for web chat readability.
+ */
+function getTailLines(raw: string, maxLines = DEFAULT_TAIL_LINES): string {
+  const lines = raw
+    .split(/\r?\n/)
+    .map((line) => line.trimEnd())
+    .filter((line) => line.length > 0);
+
+  if (lines.length <= maxLines) {
+    return lines.join("\n");
+  }
+
+  const tail = lines.slice(-maxLines);
+  const hidden = lines.length - tail.length;
+  return `...[${hidden} earlier lines omitted]...\n${tail.join("\n")}`;
+}
+
+/**
+ * Ensure the cwd exists and is a directory.
+ */
+function resolveWorkingDirectory(rawCwd?: string): string {
+  const cwd = rawCwd ? path.resolve(rawCwd) : process.cwd();
+  if (!fs.existsSync(cwd)) {
+    throw new Error(`cwd does not exist: ${cwd}`);
+  }
+  if (!fs.statSync(cwd).isDirectory()) {
+    throw new Error(`cwd is not a directory: ${cwd}`);
+  }
+  return cwd;
+}
+
+/**
+ * Ensure the codex binary is available before attempting to spawn.
+ */
+function ensureCodexInstalled(): void {
+  const pathEntries = (process.env.PATH || "").split(path.delimiter).filter(Boolean);
+  for (const entry of pathEntries) {
+    const unixCandidate = path.join(entry, "codex");
+    if (fs.existsSync(unixCandidate)) {
+      return;
+    }
+
+    const winCandidate = path.join(entry, "codex.cmd");
+    if (fs.existsSync(winCandidate)) {
+      return;
+    }
+  }
+
+  throw new Error(
+    "Codex CLI not found in PATH. Install with `pnpm add -g @openai/codex` and run `codex login`.",
+  );
 }
 
 /**
@@ -97,7 +171,7 @@ async function runCodexExec(
           child.kill("SIGKILL");
         }
       }, 3_000);
-    }, Math.max(10, waitSeconds) * 1000);
+    }, Math.max(MIN_WAIT_SECONDS, waitSeconds) * 1000);
 
     child.stdout.on("data", (chunk: Buffer | string) => {
       stdout += chunk.toString();
@@ -124,36 +198,94 @@ async function runCodexExec(
   });
 }
 
+/**
+ * Build a chat-friendly tool result with both full output and compact tails.
+ */
+function formatResult(
+  args: {
+    cwd: string;
+    approvalMode: ApprovalMode;
+    model?: string;
+    command?: string;
+    result?: Awaited<ReturnType<typeof runCodexExec>>;
+    error?: string;
+  },
+): CodexRunResult {
+  const stdout = args.result?.stdout?.trim() || "";
+  const stderr = args.result?.stderr?.trim() || "";
+  const merged = truncateOutput([stdout, stderr].filter(Boolean).join("\n\n"));
+
+  const timedOut = args.result?.timedOut ?? false;
+  const exitCode = args.result?.exitCode;
+
+  const status =
+    args.error
+      ? "failed"
+      : timedOut
+        ? "timed_out"
+        : exitCode === 0
+          ? "success"
+          : "failed";
+
+  const summaryParts = [
+    `status=${status}`,
+    `cwd=${args.cwd}`,
+    `approvalMode=${args.approvalMode}`,
+    args.model ? `model=${args.model}` : "model=default",
+    args.result ? `exitCode=${String(exitCode ?? "unknown")}` : "exitCode=not-run",
+  ];
+
+  return {
+    ok: status === "success",
+    cwd: args.cwd,
+    approvalMode: args.approvalMode,
+    model: args.model,
+    command: args.command,
+    exitCode,
+    timedOut,
+    output: merged,
+    stdoutTail: getTailLines(stdout),
+    stderrTail: getTailLines(stderr),
+    stderr,
+    error: args.error,
+    summary: summaryParts.join(" | "),
+  };
+}
+
 export function getTools(): Record<string, import("../../core/tool").CoreTool> {
   return {
     codex_run: {
       description:
-        "Run the OpenAI Codex CLI with a prompt for autonomous coding. Call when the user says 'use codex', 'run codex', or when delegating a coding task to Codex. Uses `codex exec` (non-interactive) so it works reliably from Node/AI SDK tool calls.",
+        "Run the OpenAI Codex CLI with a prompt for autonomous coding. Optimized for web chat: always returns a compact summary plus stdout/stderr tails for easy follow-up. Call when the user says 'use codex', 'run codex', or asks to delegate coding to Codex.",
       inputSchema: z.object({
         prompt: z
           .string()
+          .min(4)
           .describe(
-            "The coding task or prompt (e.g. 'Fix the failing test in utils.test.ts')",
+            "The coding task or prompt (e.g. 'Fix the failing test in utils.test.ts').",
           ),
         cwd: z
           .string()
           .optional()
           .describe(
-            "Working directory where Codex will operate (defaults to process cwd)",
+            "Working directory where Codex will operate (defaults to process cwd). Must exist.",
           ),
         waitSeconds: z
           .number()
+          .int()
+          .min(MIN_WAIT_SECONDS)
+          .max(1800)
           .optional()
-          .default(60)
+          .default(DEFAULT_WAIT_SECONDS)
           .describe(
-            "Maximum seconds to allow codex execution before timing out (default: 60).",
+            "Maximum seconds to allow Codex execution before timeout (default: 90, min: 10).",
           ),
         approvalMode: z
           .enum(["full-auto", "auto-edit", "suggest"])
           .optional()
           .default("full-auto")
           .describe(
-            "Execution mode: full-auto (Codex --full-auto), auto-edit (workspace-write sandbox), suggest (read-only suggestions).",
+            "Execution mode: full-auto (--full-auto), auto-edit (workspace-write), suggest (read-only).",
           ),
         model: z
           .string()
@@ -169,10 +301,12 @@ export function getTools(): Record<string, import("../../core/tool").CoreTool> {
         approvalMode?: ApprovalMode;
         model?: string;
       }) => {
-        const cwd = args.cwd ? path.resolve(args.cwd) : process.cwd();
-        const waitSeconds = args.waitSeconds ?? 60;
         const approvalMode = args.approvalMode ?? "full-auto";
+        const waitSeconds = args.waitSeconds ?? DEFAULT_WAIT_SECONDS;
+
         try {
+          ensureCodexInstalled();
+          const cwd = resolveWorkingDirectory(args.cwd);
           const result = await runCodexExec(
             args.prompt,
             cwd,
@@ -181,56 +315,43 @@ export function getTools(): Record<string, import("../../core/tool").CoreTool> {
             args.model,
           );
 
-          const output = truncateOutput(
-            [result.stdout, result.stderr]
-              .filter((x) => x && x.trim().length > 0)
-              .join("\n")
-              .trim(),
-          );
-
           if (result.timedOut) {
-            return {
-              ok: false,
-              error: `codex execution timed out after ${Math.max(10, waitSeconds)}s`,
-              output,
+            return formatResult({
               cwd,
               approvalMode,
               model: args.model,
-              exitCode: result.exitCode,
               command: result.command,
-            };
+              result,
+              error: `codex execution timed out after ${Math.max(MIN_WAIT_SECONDS, waitSeconds)}s`,
+            });
           }
 
           if (result.exitCode !== 0) {
-            return {
-              ok: false,
-              error: `codex exited with code ${result.exitCode ?? "unknown"}`,
-              output,
+            return formatResult({
               cwd,
               approvalMode,
               model: args.model,
-              exitCode: result.exitCode,
               command: result.command,
-            };
+              result,
+              error: `codex exited with code ${result.exitCode ?? "unknown"}`,
+            });
           }
 
-          return {
-            ok: true,
-            output,
+          return formatResult({
             cwd,
             approvalMode,
             model: args.model,
-            exitCode: result.exitCode,
             command: result.command,
-          };
+            result,
+          });
         } catch (err: any) {
-          return {
-            ok: false,
-            error: err?.message || String(err),
+          const cwd = args.cwd ? path.resolve(args.cwd) : process.cwd();
+          return formatResult({
             cwd,
             approvalMode,
             model: args.model,
-          };
+            error: err?.message || String(err),
+          });
         }
       },
     },
@@ -240,4 +361,6 @@ export function getTools(): Record<string, import("../../core/tool").CoreTool> {
 export const __private = {
   buildCodexArgs,
   truncateOutput,
+  getTailLines,
+  resolveWorkingDirectory,
 };

--- a/src/skills/index.ts
+++ b/src/skills/index.ts
@@ -13,7 +13,7 @@ export function registerDefaultSkills() {
   defaultRegistry.preRegisterTools("antigravity", getAntigravityTools());
   // Pre-register cursor-agent tools (run Cursor CLI via tmux)
   defaultRegistry.preRegisterTools("cursor-agent", getCursorAgentTools());
-  // Pre-register codex-cli tools (run Codex CLI via tmux)
+  // Pre-register codex-cli tools (run Codex CLI via non-interactive codex exec)
   defaultRegistry.preRegisterTools("codex-cli", getCodexCliTools());
   // Pre-register github tools (gh CLI for issues, PRs, branches)
   defaultRegistry.preRegisterTools("github", getGithubTools());
@@ -23,4 +23,3 @@ export function registerDefaultSkills() {
 
 // Auto-register on import
 registerDefaultSkills();
-


### PR DESCRIPTION
### Motivation
- Improve robustness and web-chat ergonomics of the `codex_run` tool by surfacing clear environment errors, bounding output, and returning structured, chat-friendly results.
- Provide opt-in live tests for longer, complex Codex flows (repository analysis / issue-fix planning) so developers can validate real-world behavior without impacting default CI.

### Description
- Hardened `src/skills/codex-cli/index.ts` by adding `ensureCodexInstalled()`, `resolveWorkingDirectory()`, `getTailLines()`, `formatResult()`, constants for time/size limits, and improved error/timeout handling to always return a structured result shape (`summary`, `stdoutTail`, `stderrTail`, `output`, `error`).
- Tightened the skill input schema with `prompt.min(4)`, integer `waitSeconds` bounds (`min: 10`, `max: 1800`, default `90`), and clearer parameter descriptions, and updated `__private` exports accordingly.
- Added and updated tests: enhanced unit tests to mock filesystem checks (`fs.existsSync`/`fs.statSync`) and assert summary/tail/timeout behaviors in `src/skills/codex-cli.test.ts`, and expanded `src/skills/codex-cli.integration.test.ts` with opt-in live basic and complex tests gated by `OPENVIBER_RUN_LIVE_CLI_TESTS` and `OPENVIBER_RUN_LIVE_CLI_COMPLEX_TESTS` respectively (complex test uses `waitSeconds: 420`).
- Documented how to run long/complex live tests and expected failure modes in `src/skills/codex-cli/SKILL.md`, and clarified the codex-cli comment in `src/skills/index.ts` to reflect non-interactive `codex exec` usage.

### Testing
- Ran unit tests with `pnpm test src/skills/codex-cli.test.ts` and integration checks in `pnpm test src/skills/codex-cli.integration.test.ts`, with both test files passing (total: 12 passed, 2 skipped in the combined run).
- Type-checked the repository with `pnpm tsc --noEmit`, which completed successfully.
- Live complex tests are opt-in and gated by environment variables (`OPENVIBER_RUN_LIVE_CLI_TESTS` and `OPENVIBER_RUN_LIVE_CLI_COMPLEX_TESTS`) and therefore were not executed by default during CI runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698806e7fc88832eaa2d1256cc85e3a7)