### PR TITLE
Daemon gateway consistency

### DIFF
--- a/docs/design/communication.md
+++ b/docs/design/communication.md
@@ -14,7 +14,7 @@ Communication in OpenViber connects operators to their vibers. The primary inter
 | Surface | Transport | Use Case |
 |---------|-----------|----------|
 | **Viber Board** (web UI) | HTTP + SSE via AI SDK | Primary: chat, observe terminals, manage vibers |
-| **CLI** | Direct daemon call | Quick tasks: `openviber run "build the landing page"` |
+| **CLI** | Direct node runtime (daemon) call | Quick tasks: `openviber run "build the landing page"` |
 | **Enterprise channels** | Channel APIs (future) | DingTalk, WeCom, Slack — async task management |
 
 ---
@@ -27,8 +27,8 @@ The Board is a SvelteKit app that communicates with vibers through the hub:
 Operator types message
   → @ai-sdk/svelte Chat class sends POST to /api/vibers/[id]/chat
     → SvelteKit API route forwards to hub: hubClient.submitTask()
-      → Hub creates task, sends task:submit to daemon over WebSocket
-        → Daemon runs AI SDK streamText(), streams response back
+      → Hub creates task, sends task:submit to node runtime (daemon) over WebSocket
+        → Node runtime (daemon) runs AI SDK streamText(), streams response back
       → Hub relays SSE stream to web app
     → Web app pipes SSE to browser
   → Chat class renders streaming response
@@ -55,7 +55,7 @@ When the operator returns to a viber's chat page:
 ### Terminal Streaming
 
 Operators can watch viber terminal sessions in real time:
-- Terminal I/O flows over the daemon ↔ hub WebSocket (separate from the AI stream).
+- Terminal I/O flows over the node runtime (daemon) ↔ hub WebSocket (separate from the AI stream).
 - The Board renders terminal output using xterm.js.
 - Operators can send keyboard input to terminals.
 - tmux is the default terminal runtime.

--- a/docs/design/openclaw-feature-comparison.md
+++ b/docs/design/openclaw-feature-comparison.md
@@ -15,11 +15,15 @@ This document compares OpenViber's feature set against [OpenClaw](https://github
 |---|---|---|
 | **Tagline** | "You Imagine It. Vibers Build It." | "Your own personal AI assistant" |
 | **Focus** | Role-scoped AI workforce for task automation | Personal AI assistant across all your devices/channels |
-| **Architecture** | Hub + Daemon + Web Board (SvelteKit) | Gateway control plane + Channels + Nodes |
+| **Architecture** | Hub (gateway control plane) + Node runtime (daemon) + Web Board (SvelteKit) | Gateway control plane + Channels + Nodes |
 | **Language** | TypeScript | TypeScript |
 | **License** | Apache 2.0 | MIT |
 | **Stars** | ~100 | ~175,000 |
 | **Deployment** | Local-first, `npx openviber start` | Local-first, `openclaw onboard --install-daemon` |
+
+Terminology mapping: OpenViber's **Hub** is the gateway control plane (OpenClaw naming),
+and OpenViber's **daemon** is the node runtime. The **enterprise channel gateway**
+(`viber gateway`) is a separate component.
 
 ---
 

--- a/docs/design/viber.md
+++ b/docs/design/viber.md
@@ -239,9 +239,12 @@ This single command:
 
 ---
 
-## 9. Gateway Control Plane
+## 9. Gateway Control Plane (Hub)
 
-After onboarding, the node communicates with the Board via a WebSocket control plane:
+After onboarding, the node communicates with the Board via a WebSocket control plane.
+In this repo, that control plane is implemented by the **Hub** service and aligns with
+OpenClaw's "gateway" naming. This is distinct from the **enterprise channel gateway**
+(`viber gateway`) and from the **node runtime** (often called the daemon).
 
 - **Single gateway per host** — one node is the authority for channel connections and viber runs on that machine.
 - **WebSocket control plane** — all clients (Board, CLI, automation) connect over a typed WS protocol, declaring **role + scopes** at handshake.

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -39,11 +39,30 @@ The accumulated information that vibers use to understand and respond to request
 
 The complete record of messages between users and vibers within a Space. History persists across sessions, enabling vibers to maintain continuity.
 
+## D
+
+### Daemon (Node Runtime)
+
+The local process running on a Viber Node that executes tasks and connects outbound to the Hub
+control plane. In docs, "daemon" and "node runtime" are used interchangeably.
+
+## G
+
+### Gateway
+
+The enterprise channel gateway started with `viber gateway` (DingTalk, WeCom, etc.). This is
+distinct from the Hub's gateway control plane role.
+
 ## H
 
 ### History
 
 See [Conversation History](#conversation-history).
+
+### Hub (Gateway Control Plane)
+
+The central coordinator that routes messages between node runtimes (daemons) and the web app.
+This is the "gateway control plane" role in OpenClaw terminology.
 
 ## J
 
@@ -159,7 +178,7 @@ Vibers are configured through YAML files in `~/.openviber/vibers/`.
 
 A machine running the OpenViber runtime that hosts one or more vibers. A Viber Node provides:
 
-- **Runtime** — The process that executes viber tasks
+- **Runtime** — The node runtime (daemon) process that executes viber tasks and connects to the Hub
 - **Scheduler** — Cron-based job scheduling for automated tasks
 - **Credentials** — Shared account access for hosted vibers
 - **Config** — Identity and viber settings at `~/.openviber/` (lightweight, portable)


### PR DESCRIPTION
Clarify terminology for "daemon", "node runtime", "hub", and "gateway" in documentation to reduce confusion and align with OpenClaw naming.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-5455f72a-0634-4d0f-a9f3-cfe739547493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5455f72a-0634-4d0f-a9f3-cfe739547493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

