### PR TITLE
Improve Railway tool repo-context deployment discovery

### DIFF
--- a/src/skills/railway/SKILL.md
+++ b/src/skills/railway/SKILL.md
@@ -13,7 +13,7 @@ Manage Railway deployments directly from Viber. Uses the Railway CLI (`railway`)
 Install Railway CLI:
 
 ```bash
-npm install -g @railway/cli
+pnpm add -g @railway/cli
 # or
 brew install railway
 ```
@@ -43,25 +43,28 @@ railway link
 
 ### railway_status
 - `service` (optional): Service name to check (defaults to all services)
+- `cwd` (optional): Working directory (if unlinked/mismatched, auto-discovery will try matching repo-related project/service contexts)
 
 ### railway_logs
 - `service` (optional): Service name to get logs for
 - `lines` (optional): Number of log lines (default: 50, max: 500)
 - `deploymentId` (optional): Deployment ID to fetch logs for (if omitted, uses latest deployment)
+- `cwd` (optional): Working directory (if unlinked/mismatched, auto-discovery will try matching repo-related project/service contexts)
 
 ### railway_deploy
 - `service` (optional): Service to redeploy
+- `cwd` (optional): Working directory (if unlinked/mismatched, auto-discovery will try matching repo-related project/service contexts)
 
 ### railway_deployments
-- `cwd` (optional): Working directory (must be a linked Railway project)
+- `cwd` (optional): Working directory (if unlinked/mismatched, auto-discovery will try matching repo-related project/service contexts)
 
 ### railway_build_logs
 - `deploymentId` (required): Deployment ID (UUID from railway_deployments output)
-- `cwd` (optional): Working directory
+- `cwd` (optional): Working directory (if unlinked/mismatched, auto-discovery will try matching repo-related project/service contexts)
 
 ### railway_run
 - `command` (required): Railway CLI subcommand and arguments (e.g. `variables list`)
-- `cwd` (optional): Working directory (must be a linked Railway project)
+- `cwd` (optional): Working directory (if unlinked/mismatched, auto-discovery will try matching repo-related project/service contexts)
 
 ## Usage from Viber
 

--- a/src/skills/railway/index.ts
+++ b/src/skills/railway/index.ts
@@ -542,8 +542,12 @@ export function getTools(): Record<string, import("../../core/tool").CoreTool> {
           const cwd = resolveWorkingDirectory(args.cwd);
           const cmdArgs = ["up", "--detach"];
           if (args.service) cmdArgs.push("--service", args.service);
-          const result = await runRailway(cmdArgs, cwd, 120);
-          return formatResult({ ...result, exitCode: result.exitCode });
+          return await runWithDiscovery({
+            cwd,
+            serviceHint: args.service,
+            commandArgs: cmdArgs,
+            timeoutSeconds: 120,
+          });
         } catch (err: any) {
           return {
             ok: false,
@@ -578,8 +582,11 @@ export function getTools(): Record<string, import("../../core/tool").CoreTool> {
           ensureRailwayCli();
           const cwd = resolveWorkingDirectory(args.cwd);
           const cmdArgs = args.command.split(/\s+/).filter(Boolean);
-          const result = await runRailway(cmdArgs, cwd, 60);
-          return formatResult({ ...result, exitCode: result.exitCode });
+          return await runWithDiscovery({
+            cwd,
+            commandArgs: cmdArgs,
+            timeoutSeconds: 60,
+          });
         } catch (err: any) {
           return {
             ok: false,


### PR DESCRIPTION
### Motivation
- Redeploy and ad-hoc Railway CLI commands should succeed even when the provided `cwd` is not linked to the correct Railway project/service by falling back to repo-based discovery. 
- Documentation and install instructions should follow workspace conventions (`pnpm`) and clearly indicate `cwd` and auto-discovery behavior for users of the Railway skill.

### Description
- Route `railway_deploy` through the existing discovery flow by replacing the direct `runRailway(...)` call with `runWithDiscovery({ cwd, serviceHint: args.service, commandArgs, timeoutSeconds: 120 })` so redeploys can recover when linkage is missing or mismatched. 
- Route `railway_run` through `runWithDiscovery(...)` instead of directly calling `runRailway(...)` so arbitrary Railway commands also use discovery fallback. 
- Update `src/skills/railway/SKILL.md` to use `pnpm add -g @railway/cli` and document `cwd` support and the auto-discovery behavior consistently for `railway_status`, `railway_logs`, `railway_deploy`, `railway_deployments`, `railway_build_logs`, and `railway_run`.

### Testing
- Ran the TypeScript typecheck with `pnpm -s tsc --noEmit`, which reported failures, but these are due to existing unrelated type errors in other modules (`src/channels/*`, `src/skills/hub/settings.ts`, `src/tools/*.test.ts`) and not from the Railway-skill changes. 
- Verified locally that the Railway skill changes replace direct `runRailway` usage with `runWithDiscovery` for `railway_deploy` and `railway_run` and that the `SKILL.md` documentation reflects the new behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698afba0cce8832e93e881f51d1f9983)