### PR TITLE
Update runtime and CLI terminology to match Viber/Task model

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # OpenViber
 
-### You Imagine It. Vibers Build It.
+### You Imagine It. Tasks Build It.
 
 [![Download][download-shield]][viber-npm]
 [![GitHub Stars][github-star]][viber-github]
@@ -17,12 +17,12 @@
 
 ---
 
-**OpenViber** is an open-source platform that turns your machine into a **Viber Node** — hosting role-scoped AI workers called **vibers** that automate real work. Unlike cloud-based agent frameworks, OpenViber runs locally with full privacy, connects outbound to your enterprise channels, and works autonomously while you sleep.
+**OpenViber** is an open-source platform that turns your machine into a **Viber** — hosting role-scoped AI workers called **tasks** that automate real work. Unlike cloud-based agent frameworks, OpenViber runs locally with full privacy, connects outbound to your enterprise channels, and works autonomously while you sleep.
 
 ### ⭐ 100% Open Source · 🥇 Local Deployment · 🏆 MCP Integration
 
 - ✅ **Zero Setup** — No servers to host, just `npx openviber start`
-- ✅ **Viber Workforce** — Role-scoped vibers working in parallel
+- ✅ **Task Workforce** — Role-scoped tasks working in parallel
 - ✅ **Human-in-the-Loop** — Enterprise messaging channels (DingTalk, WeCom)
 - ✅ **Privacy First** — 100% local execution, data never leaves your machine
 
@@ -69,7 +69,7 @@ cp .env.example .env
 
 ### 3. Launch full stack
 ```bash
-# Starts Hub, Viber Node, and Web UI
+# Starts Hub, Viber runtime, and Web UI
 pnpm dev
 ```
 - **Viber Board (Web UI)**: [http://localhost:6006](http://localhost:6006)
@@ -93,7 +93,7 @@ viber chat
 ```
 
 ### 🌐 Viber Board (Web UI)
-A modern, visual interface to manage your viber nodes, monitor jobs, and chat in real-time. Accessible at `http://localhost:6006` when running `pnpm dev`.
+A modern, visual interface to manage your vibers, monitor jobs, and chat in real-time. Accessible at `http://localhost:6006` when running `pnpm dev`.
 
 ### 🏢 Enterprise Channels
 Deploy your vibers to where your team works. Support for **DingTalk** and **WeCom** is built-in.
@@ -107,13 +107,13 @@ viber channels
 
 ## 🧠 Personalization (The Three-File Pattern)
 
-OpenViber follows a standardized configuration pattern for AI personality. Three markdown files define your viber's complete behavior:
+OpenViber follows a standardized configuration pattern for AI personality. Three markdown files define your task's complete behavior:
 
 | File | Scope | Purpose | Update Frequency |
 |------|-------|---------|------------------|
 | **`user.md`** | Shared | Who you are, current projects, priorities | Daily/Weekly |
-| **`soul.md`** | Per-viber | Communication style, boundaries, rules | Monthly |
-| **`memory.md`** | Per-viber | Decisions, learned patterns, corrections | Grows organically |
+| **`soul.md`** | Per-task | Communication style, boundaries, rules | Monthly |
+| **`memory.md`** | Per-task | Decisions, learned patterns, corrections | Grows organically |
 
 Location: `~/.openviber/vibers/default/`
 
@@ -131,7 +131,7 @@ prompt: "Check GitHub notifications, summarize what needs my attention."
 ```
 
 ### 🔧 Zero Configuration Skills
-Capabilities are defined in `SKILL.md` files. No complex code required to extend your viber.
+Capabilities are defined in `SKILL.md` files. No complex code required to extend your tasks.
 ```markdown
 ---
 name: git-commit
@@ -141,10 +141,10 @@ git add . && git commit -m "$message"
 ```
 
 ### 🌐 Model Context Protocol (MCP)
-Seamlessly connect to any MCP server to give your vibers access to external tools like Google Maps, Slack, or custom internal APIs.
+Seamlessly connect to any MCP server to give your tasks access to external tools like Google Maps, Slack, or custom internal APIs.
 
 ### 👤 Human-in-the-Loop
-Maintain control with approval gates. Vibers can be configured to pause and ask for permission before executing sensitive actions (e.g., deleting files, making payments).
+Maintain control with approval gates. Tasks can be configured to pause and ask for permission before executing sensitive actions (e.g., deleting files, making payments).
 
 ---
 
@@ -152,7 +152,7 @@ Maintain control with approval gates. Vibers can be configured to pause and ask 
 
 ```
 ┌─────────────────────────────────────────────────┐
-│                  Viber Node                     │
+│                    Viber                        │
 │                                                 │
 │  ┌────────────────────────────────────────────┐  │
 │  │  dev-viber │ researcher-viber │ pm-viber   │  │
@@ -181,7 +181,7 @@ Maintain control with approval gates. Vibers can be configured to pause and ask 
 
 | Feature | OpenViber | Cloud Agents | IDE Plugins |
 | :--- | :---: | :---: | :---: |
-| **Deployment** | Local Node | Cloud Server | Editor Only |
+| **Deployment** | Local Viber | Cloud Server | Editor Only |
 | **Connectivity** | Outbound | Inbound/Cloud | None |
 | **Autonomy** | Full (Jobs/Cron) | Managed | Manual Trigger |
 | **Privacy** | 100% Local | Data Leaves | Limited |

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -5,9 +5,9 @@ description: "You Imagine It. Vibers Build It."
 
 # Introduction
 
-**You Imagine It. Vibers Build It.**
+**You Imagine It. Tasks Build It.**
 
-**OpenViber** is an open-source platform that turns your machine into a **Viber Node** — hosting role-scoped AI workers called **vibers** that handle real tasks autonomously. Runs locally with full privacy, connects to your channels, and works while you sleep.
+**OpenViber** is an open-source platform that turns your machine into a **Viber** — hosting role-scoped AI workers called **tasks** that handle real work autonomously. Runs locally with full privacy, connects to your channels, and works while you sleep.
 
 The CLI is available as both `openviber` and the shorter alias `viber` (when installed).
 
@@ -29,7 +29,7 @@ OpenViber handles tasks that require multiple steps, file operations, web browsi
 Open the browser-based interface to chat with your viber:
 
 ```bash
-# Start the full stack (Gateway, Viber Node, and Web UI)
+# Start the full stack (Gateway, Viber runtime, and Web UI)
 pnpm dev
 # Open http://localhost:6006
 ```
@@ -63,9 +63,9 @@ openviber channels
 
 | Concept | What It Is |
 |---------|------------|
-| **Viber** | A role-scoped AI worker with its own persona, goals, and tools |
-| **Viber Node** | Your machine running OpenViber — hosts one or more vibers |
-| **Tools** | Actions vibers can take (file, search, web, browser, desktop, schedule, notify) |
+| **Task** | A role-scoped AI worker with its own persona, goals, and tools |
+| **Viber** | Your machine running OpenViber — hosts one or more tasks |
+| **Tools** | Actions tasks can take (file, search, web, browser, desktop, schedule, notify) |
 | **Skills** | Domain knowledge bundles (`SKILL.md` + optional tools) — antigravity, cursor-agent, codex-cli, github, tmux |
 | **Jobs** | Cron-scheduled YAML tasks that run agents autonomously on a timer |
 
@@ -75,16 +75,16 @@ OpenViber supports three levels of autonomy:
 
 | Mode | Behavior |
 |------|----------|
-| **Always Ask** | Viber asks before each action — you approve everything |
-| **Viber Decides** | Viber acts within policy, escalates risky actions |
+| **Always Ask** | Task asks before each action — you approve everything |
+| **Task Decides** | Task acts within policy, escalates risky actions |
 | **Always Execute** | Maximum autonomy, intervene by exception |
 
 Start with "Always Ask" and gradually increase autonomy as you build trust.
 
 ## Next Steps
 
-1. **[Quick Start](/docs/getting-started/quick-start)** — Run your first viber in minutes
-2. **[Viber](/docs/concepts/viber)** — Configure viber behavior
+1. **[Quick Start](/docs/getting-started/quick-start)** — Run your first task in minutes
+2. **[Viber Runtime](/docs/concepts/viber)** — Configure task behavior on your machine
 3. **[Jobs](/docs/concepts/jobs)** — Set up scheduled tasks
 4. **[Tools](/docs/concepts/tools)** — Available actions
 5. **[Skills](/docs/concepts/skills)** — Add domain knowledge

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -171,9 +171,9 @@ A capability that extends what vibers can do. Tools allow vibers to:
 
 ## V
 
-### Viber
+### Task
 
-A role-scoped AI worker that runs on a Viber Node. Each viber has its own:
+A role-scoped AI worker that runs on a Viber. Each task has its own:
 
 - **Persona** — Name, personality, communication style
 - **Goals** — What it's designed to accomplish
@@ -181,19 +181,19 @@ A role-scoped AI worker that runs on a Viber Node. Each viber has its own:
 - **Skills** — Domain knowledge it applies
 - **Model** — Which LLM provider it uses
 
-Vibers are configured through YAML files in `~/.openviber/vibers/`.
+Tasks are configured through YAML files in `~/.openviber/vibers/`.
 
-### Viber Node
+### Viber
 
-A machine running the OpenViber runtime that hosts one or more vibers. A Viber Node provides:
+A machine running the OpenViber runtime that hosts one or more tasks. A Viber provides:
 
 - **Runtime** — The node runtime (daemon) process that executes viber tasks and connects to the Gateway
 - **Scheduler** — Cron-based job scheduling for automated tasks
-- **Credentials** — Shared account access for hosted vibers
+- **Credentials** — Shared account access for hosted tasks
 - **Config** — Identity and viber settings at `~/.openviber/` (lightweight, portable)
 - **Spaces** — Working data at `~/openviber_spaces/` (repos, research, outputs)
 
-Nodes connect to the OpenViber Board via a one-time token command (`npx openviber connect --token ...`). Multiple vibers on one node coordinate through external systems (GitHub, email) rather than direct inter-viber messaging.
+Nodes connect to the OpenViber Board via a one-time token command (`npx openviber connect --token ...`). Multiple tasks on one machine coordinate through external systems (GitHub, email) rather than direct inter-viber messaging.
 
 ### ViberAgent
 
@@ -212,8 +212,8 @@ The core class that orchestrates a viber's task execution. ViberAgent:
 
 | Concept | Definition |
 |---------|-----------|
-| **Viber** | A role-scoped AI worker with persona, goals, tools, and skills |
-| **Viber Node** | A machine running OpenViber, hosting one or more vibers |
+| **Task** | A role-scoped AI worker with persona, goals, tools, and skills |
+| **Viber** | A machine running OpenViber, hosting one or more tasks |
 | **Space** | A persistent workspace container for a viber's work |
 | **Skill** | Domain knowledge bundle (`SKILL.md` + optional tools) that teaches agents domain-specific approaches |
 | **Tool** | An action capability (file ops, terminal, browser, search) |
@@ -223,8 +223,8 @@ The core class that orchestrates a viber's task execution. ViberAgent:
 
 | Pattern | Description |
 |---------|-------------|
-| **Single Viber** | One viber per node for general-purpose use |
-| **Multi-Viber Team** | Multiple role-scoped vibers on one node coordinating via GitHub |
+| **Single Task** | One task per machine for general-purpose use |
+| **Multi-Task Team** | Multiple role-scoped tasks on one machine coordinating via GitHub |
 | **Scheduled Jobs** | Cron-triggered tasks using skills for automated workflows (health checks, daily summaries) |
 | **Skill Chains** | Combining skills (e.g., github + codex-cli) for end-to-end autonomous workflows |
 | **Chat-Created Jobs** | Creating scheduled jobs via natural language in the Viber Board |

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,11 +7,11 @@ import "dotenv/config";
  * Viber CLI - Command line interface for the Viber framework
  *
  * Commands:
- *   viber start    - Start the viber daemon (connect to command center)
+ *   viber start    - Start the Viber runtime (connect to command center)
  *   viber run      - Run a task locally without connection to command center
- *   viber chat     - Chat with a running viber via the local gateway (terminal-first)
+ *   viber chat     - Chat with a running task via the local gateway (terminal-first)
  *   viber term     - List/attach/send input to tmux panes via local WS (port 6008)
- *   viber gateway  - Start the gateway (central coordinator for vibers)
+ *   viber gateway  - Start the gateway (central coordinator for tasks)
  *   viber channels - Start the enterprise channel server (DingTalk, WeCom, etc.)
  */
 
@@ -61,7 +61,7 @@ function getCliName(): string {
 
 program
   .name(getCliName())
-  .description("OpenViber - Workspace-first assistant runtime (vibers on your machines)")
+  .description("OpenViber - Workspace-first assistant runtime (tasks on your Viber)")
   .version(VERSION);
 
 // ==================== viber start ====================
@@ -69,7 +69,7 @@ program
 program
   .command("start")
   .description(
-    "Start viber daemon (auto-connects if previously onboarded with --token)",
+    "Start Viber runtime daemon (auto-connects if previously onboarded with --token)",
   )
   .option("-s, --server <url>", "Command center URL (overrides saved config)")
   .option("-t, --token <token>", "Authentication token (overrides saved config)")
@@ -331,17 +331,17 @@ const gatewayAction = async (options: { port: string }) => {
 +-------------------------------------------------------+
 | REST API:     ${("http://localhost:" + options.port).padEnd(43).slice(0, 43)} |
 | WebSocket:    ${("ws://localhost:" + options.port + "/ws").padEnd(43).slice(0, 43)} |
-| Status:       * Ready for viber connections             |
+| Status:       * Ready for task connections              |
 +-------------------------------------------------------+
 
-Waiting for viber daemons to connect...
+Waiting for Viber runtimes to connect...
 Press Ctrl+C to stop.
   `);
 };
 
 program
   .command("gateway")
-  .description("Start the gateway (central coordinator for viber daemons)")
+  .description("Start the gateway (central coordinator for Viber runtimes)")
   .option("-p, --port <port>", "Port to listen on", "6007")
   .action(gatewayAction);
 
@@ -400,7 +400,7 @@ program
 program
   .command("chat")
   .description(
-    "Chat with a running viber via the local gateway (works great inside tmux)",
+    "Chat with a running task via the local gateway (works great inside tmux)",
   )
   .option(
     "--gateway <url>",
@@ -414,7 +414,7 @@ program
     "--hub <url>",
     "(deprecated: use --gateway) Gateway URL",
   )
-  .option("-v, --viber <id>", "Target viber ID (defaults to first connected)")
+  .option("-v, --viber <id>", "Target task runtime ID (defaults to first connected)")
   .option(
     "-s, --session <name>",
     "Session name for local history (saved under ~/.openviber/vibers/default/sessions/)",
@@ -443,8 +443,8 @@ program
 
     const vibers = await hubGetVibers(gatewayUrl);
     if (!vibers.connected || vibers.vibers.length === 0) {
-      console.error(`[Chat] No vibers connected to gateway at ${gatewayUrl}`);
-      console.error("[Chat] Start the gateway + viber in another terminal:");
+      console.error(`[Chat] No tasks connected to gateway at ${gatewayUrl}`);
+      console.error("[Chat] Start the gateway + Viber runtime in another terminal:");
       console.error("  pnpm dev  (or: pnpm dev:gateway + pnpm dev:viber)");
       process.exit(1);
     }
@@ -453,9 +453,9 @@ program
     if (activeViberId) {
       const exists = vibers.vibers.some((v) => v.id === activeViberId);
       if (!exists) {
-        console.error(`[Chat] Viber not found: ${activeViberId}`);
+        console.error(`[Chat] Task runtime not found: ${activeViberId}`);
         console.error(
-          `[Chat] Connected vibers:\n${vibers.vibers.map((v) => `  - ${v.id} (${v.name})`).join("\n")}`,
+          `[Chat] Connected tasks:\n${vibers.vibers.map((v) => `  - ${v.id} (${v.name})`).join("\n")}`,
         );
         process.exit(1);
       }
@@ -1923,8 +1923,8 @@ async function handleChatCommand(
           "Commands:",
           "  /help                 Show help",
           "  /exit                 Exit chat",
-          "  /vibers               List connected vibers",
-          "  /use <viberId>        Switch viber",
+          "  /vibers               List connected tasks",
+          "  /use <viberId>        Switch active task runtime",
           "  /reset                Clear local history (and session file)",
         ].join("\n"),
       );
@@ -1932,10 +1932,10 @@ async function handleChatCommand(
     case "vibers": {
       const vibers = await hubGetVibers(ctx.hubUrl);
       if (!vibers.connected || vibers.vibers.length === 0) {
-        console.log("No vibers connected.");
+        console.log("No tasks connected.");
         return "continue";
       }
-      console.log("Connected vibers:");
+      console.log("Connected tasks:");
       for (const v of vibers.vibers) {
         const active = v.id === ctx.getActiveViberId() ? " (active)" : "";
         console.log(`  - ${v.id} (${v.name})${active}`);
@@ -1951,11 +1951,11 @@ async function handleChatCommand(
       const vibers = await hubGetVibers(ctx.hubUrl);
       const exists = vibers.vibers.some((v) => v.id === next);
       if (!exists) {
-        console.log(`Viber not found: ${next}`);
+        console.log(`Task runtime not found: ${next}`);
         return "continue";
       }
       ctx.setActiveViberId(next);
-      console.log(`Active viber: ${next}`);
+      console.log(`Active task runtime: ${next}`);
       return "continue";
     }
     case "reset":

--- a/src/daemon/gateway.ts
+++ b/src/daemon/gateway.ts
@@ -968,7 +968,7 @@ export class GatewayServer {
     const viber = this.vibers.get(viberId);
     if (viber) {
       viber.status = "running";
-      console.log(`[Gateway] Viber started: ${viberId}`);
+      console.log(`[Gateway] Task started: ${viberId}`);
     }
   }
 
@@ -981,7 +981,7 @@ export class GatewayServer {
       if (typeof result?.text === "string") {
         viber.partialText = result.text;
       }
-      console.log(`[Gateway] Viber completed: ${viberId}`);
+      console.log(`[Gateway] Task completed: ${viberId}`);
 
       // Close SSE stream subscribers
       this.closeStreamSubscribers(viberId);
@@ -1041,7 +1041,7 @@ export class GatewayServer {
       viber.status = "error";
       viber.error = error;
       viber.completedAt = new Date();
-      console.log(`[Gateway] Viber error: ${viberId} - ${error}${model ? ` (model: ${model})` : ""}`);
+      console.log(`[Gateway] Task error: ${viberId} - ${error}${model ? ` (model: ${model})` : ""}`);
 
       // Push an error event so it appears in the /api/events stream (and Logs page)
       const now = new Date().toISOString();

--- a/src/daemon/node-status.ts
+++ b/src/daemon/node-status.ts
@@ -1,9 +1,9 @@
 /**
- * Node Status Collector - Machine Resource & Viber Running Status
+ * Node Status Collector - Machine Resource & Task Runtime Status
  *
- * Collects comprehensive observability data for a viber node including:
+ * Collects comprehensive observability data for a Viber runtime including:
  * - Machine resources: CPU, memory, disk, load, network
- * - Viber running status: tasks, uptime, connection health
+ * - Task runtime status: tasks, uptime, connection health
  *
  * Uses only Node.js built-in modules (os, fs, child_process) — no extra deps.
  */
@@ -112,7 +112,7 @@ export interface MachineResourceStatus {
   collectedAt: string;
 }
 
-/** Information about a running task on this viber */
+/** Information about a running task on this Viber runtime */
 export interface RunningTaskInfo {
   /** Task ID */
   taskId: string;
@@ -507,9 +507,9 @@ export function formatNodeStatus(status: NodeObservabilityStatus): string {
 
   // Viber section
   lines.push(border);
-  lines.push(line("VIBER RUNNING STATUS"));
+  lines.push(line("TASK RUNTIME STATUS"));
   lines.push(border);
-  lines.push(line("Viber ID:    " + v.viberId.slice(0, 42)));
+  lines.push(line("Runtime ID:  " + v.viberId.slice(0, 42)));
   lines.push(line("Name:        " + v.viberName.slice(0, 42)));
   lines.push(line("Version:     " + v.version.slice(0, 42)));
   lines.push(line("Connected:   " + (v.connected ? "* Yes" : "o No")));

--- a/web/src/routes/(viberboard)/vibers/+page.svelte
+++ b/web/src/routes/(viberboard)/vibers/+page.svelte
@@ -114,20 +114,20 @@
 </script>
 
 <svelte:head>
-  <title>Vibers - OpenViber</title>
+  <title>Tasks - OpenViber</title>
 </svelte:head>
 
 <div class="p-6 h-full overflow-y-auto flex flex-col">
   <div class="flex items-center justify-between mb-6">
     <div>
-      <h1 class="text-2xl font-semibold text-foreground">Vibers</h1>
+      <h1 class="text-2xl font-semibold text-foreground">Tasks</h1>
       <p class="text-sm mt-0.5 text-muted-foreground flex items-center gap-2">
         {#if hubConnected}
           <span class="flex items-center gap-1">
             <Circle class="size-2 fill-green-500 text-green-500" />
             Hub connected
           </span>
-          · {vibers.length} viber{vibers.length !== 1 ? "s" : ""}
+          · {vibers.length} task{vibers.length !== 1 ? "s" : ""}
         {:else}
           <span class="flex items-center gap-1">
             <Circle class="size-2 fill-red-500 text-red-500" />
@@ -147,7 +147,7 @@
       </Button>
       <Button variant="outline" size="sm" href="/vibers/new">
         <Plus class="size-4 mr-1" />
-        New Viber
+        New Task
       </Button>
       <Button
         variant="outline"
@@ -226,7 +226,7 @@
                       variant="ghost"
                       size="icon"
                       class="size-7"
-                      title="Archive viber"
+                      title="Archive task"
                       disabled={busyViberIds.has(viber.id)}
                       onclick={(e: MouseEvent) => archiveViber(viber.id, e)}
                     >
@@ -261,10 +261,10 @@
   {:else}
     <div class="flex-1 flex flex-col items-center justify-center text-center">
       <Server class="size-12 mb-4 text-muted-foreground/50" />
-      <p class="text-lg font-medium text-muted-foreground">No Vibers Yet</p>
+      <p class="text-lg font-medium text-muted-foreground">No Tasks Yet</p>
       <p class="text-sm mt-2 max-w-md text-muted-foreground">
-        Create a new viber from the
-        <a href="/vibers/new" class="text-primary hover:underline">New Viber</a>
+        Create a new task from the
+        <a href="/vibers/new" class="text-primary hover:underline">New Task</a>
         page to get started.
       </p>
     </div>

--- a/web/src/routes/(viberboard)/vibers/[id]/jobs/+page.svelte
+++ b/web/src/routes/(viberboard)/vibers/[id]/jobs/+page.svelte
@@ -28,7 +28,7 @@
     <header class="mb-8">
       <h1 class="text-3xl font-bold text-foreground mb-2">Scheduled Jobs</h1>
       <p class="text-muted-foreground">
-        Automated tasks that run on a schedule for this Viber.
+        Automated tasks that run on a schedule for this task.
       </p>
     </header>
 
@@ -48,7 +48,7 @@
           No jobs configured
         </h2>
         <p class="text-muted-foreground text-sm max-w-md mx-auto mb-6">
-          Ask the Viber to schedule a job for you, or create a YAML file
+          Ask the task to schedule a job for you, or create a YAML file
           manually.
         </p>
         <a

--- a/web/src/routes/(viberboard)/vibers/new/+page.svelte
+++ b/web/src/routes/(viberboard)/vibers/new/+page.svelte
@@ -229,7 +229,7 @@
 
       const payload = await response.json();
       if (!response.ok) {
-        throw new Error(payload?.error || "Failed to create viber.");
+        throw new Error(payload?.error || "Failed to create task.");
       }
 
       const viberId = payload.viberId;
@@ -246,7 +246,7 @@
       // Navigate to the new viber's chat page
       await goto(`/vibers/${viberId}`);
     } catch (e) {
-      error = e instanceof Error ? e.message : "Failed to create viber.";
+      error = e instanceof Error ? e.message : "Failed to create task.";
       creating = false;
     }
   }
@@ -258,7 +258,7 @@
 </script>
 
 <svelte:head>
-  <title>New Viber - OpenViber</title>
+  <title>New Task - OpenViber</title>
 </svelte:head>
 
 <div class="new-task-page flex h-full min-h-0 flex-col overflow-hidden">


### PR DESCRIPTION
### Motivation
- Align user-facing runtime and CLI copy with the new conceptual model where the host runtime is a `Viber` and the worker is a `Task`. 
- Extend the earlier docs and web UI wording changes into the runtime and CLI so operational logs and interactive messages match the same terminology.

### Description
- Updated CLI user-facing strings in `src/cli/index.ts` to use task-centric wording (command descriptions, gateway banner, chat/help messages, error messages, and prompts) while preserving command names and internal IDs. 
- Updated gateway lifecycle logs in `src/daemon/gateway.ts` to change operational log lines from "Viber started/completed/error" to "Task started/completed/error". 
- Adjusted observability wording and formatted output in `src/daemon/node-status.ts` (file header, comments, `VIBER RUNNING STATUS` → `TASK RUNTIME STATUS`, `Viber ID` → `Runtime ID`, and related docstrings). 
- Kept API paths and internal identifiers (e.g. `/api/vibers`, `viberId`) intact for backward compatibility; the changes are limited to user-visible copy and formatted output. 

### Testing
- Ran `pnpm -s typecheck` which reported failures, but these are pre-existing unrelated TypeScript errors in channel integrations/tests and are not caused by the terminology-only string changes. 
- No unit or integration tests were added or modified for this PR, and no runtime behavior changes were introduced beyond logging and UI/CLI copy updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c164fde54832e86fb88f996987151)