### PR TITLE
feat(web): add scenario-driven skills playground and richer result details

### DIFF
--- a/web/src/routes/(viberboard)/skills/+page.svelte
+++ b/web/src/routes/(viberboard)/skills/+page.svelte
@@ -24,6 +24,7 @@
   import * as Dialog from "$lib/components/ui/dialog";
   import * as DropdownMenu from "$lib/components/ui/dropdown-menu";
   import { Button } from "$lib/components/ui/button";
+  import { Textarea } from "$lib/components/ui/textarea";
 
   interface UnmetRequirement {
     type: "oauth" | "env" | "bin";
@@ -125,6 +126,7 @@
   let playgroundRunning = $state(false);
   let playgroundError = $state<string | null>(null);
   let playgroundResult = $state<PlaygroundResult | null>(null);
+  let playgroundScenario = $state("");
 
   const enabledSources = $derived(sources.filter((s) => s.enabled));
   const enabledSourcesCount = $derived(enabledSources.length);
@@ -371,6 +373,7 @@
         body: JSON.stringify({
           skillId: playgroundSkill.id,
           nodeId: selectedNode?.node_id || selectedNode?.id,
+          scenario: playgroundScenario.trim() || undefined,
         }),
       });
       const data = await res.json().catch(() => ({}));
@@ -393,6 +396,7 @@
     playgroundSkill = null;
     playgroundError = null;
     playgroundResult = null;
+    playgroundScenario = "";
   }
 
   $effect(() => {
@@ -866,6 +870,20 @@
         <div class="rounded-md border border-border bg-muted/20 p-3 text-xs text-muted-foreground">
           This creates a temporary viber on the selected node and asks it to run the playground verification flow for the selected skill.
         </div>
+
+
+        <div class="space-y-2">
+          <p class="text-xs font-medium text-muted-foreground">Scenario (optional)</p>
+          <Textarea
+            bind:value={playgroundScenario}
+            class="min-h-24"
+            placeholder="Optional: describe a specific user flow or edge case you want this skill to execute."
+          />
+          <p class="text-[11px] text-muted-foreground">
+            Leave blank to run the default verification flow.
+          </p>
+        </div>
+
       {/if}
 
       {#if playgroundError}
@@ -885,6 +903,18 @@
           <p><span class="font-medium">Viber:</span> {playgroundResult.viberId}</p>
           {#if playgroundResult.message}
             <p><span class="font-medium">Message:</span> {playgroundResult.message}</p>
+          {/if}
+          {#if playgroundResult.partialText}
+            <div class="space-y-1">
+              <p class="font-medium">Model summary</p>
+              <pre class="max-h-56 overflow-auto rounded-md border border-border bg-background p-2 text-[11px] whitespace-pre-wrap">{playgroundResult.partialText}</pre>
+            </div>
+          {/if}
+          {#if playgroundResult.result}
+            <details>
+              <summary class="cursor-pointer font-medium">Raw result payload</summary>
+              <pre class="mt-2 max-h-64 overflow-auto rounded-md border border-border bg-background p-2 text-[11px]">{JSON.stringify(playgroundResult.result, null, 2)}</pre>
+            </details>
           {/if}
         </div>
       {/if}

--- a/web/src/routes/api/skills/playground/+server.ts
+++ b/web/src/routes/api/skills/playground/+server.ts
@@ -5,6 +5,7 @@ import { gatewayClient } from "$lib/server/gateway-client";
 interface PlaygroundRequestBody {
   skillId?: string;
   nodeId?: string;
+  scenario?: string;
 }
 
 interface PollResult {
@@ -81,16 +82,23 @@ export const POST: RequestHandler = async ({ request, locals }) => {
     const body = (await request.json()) as PlaygroundRequestBody;
     const skillId = body.skillId?.trim();
     const nodeId = body.nodeId?.trim();
+    const scenario = body.scenario?.trim();
 
     if (!skillId) {
       return json({ error: "Missing skillId" }, { status: 400 });
     }
 
-    const prompt = [
+    const promptSections = [
       `Playground verification for skill: ${skillId}`,
       "Run the skill's built-in playground verification workflow (for example, call skill_playground_verify when available).",
       "Then summarize whether it worked, what checks were performed, and any setup issues found.",
-    ].join("\n\n");
+    ];
+
+    if (scenario) {
+      promptSections.push(`Scenario to execute:\n${scenario}`);
+    }
+
+    const prompt = promptSections.join("\n\n");
 
     const created = await gatewayClient.createViber(prompt, nodeId || undefined);
     if (!created?.viberId) {


### PR DESCRIPTION
### Motivation

- Make it easy to run targeted verification flows on a specific node by allowing an optional scenario description to be sent with playground runs. 
- Improve observability of playground runs so users can quickly see a model summary and raw payload when troubleshooting skill executions.

### Description

- Added a shadcn `Textarea` to the Skills page playground dialog bound to `playgroundScenario` so users can enter an optional scenario to exercise a skill. 
- Wired `playgroundScenario` into the playground POST request body and reset it when the dialog closes. 
- Updated the playground API (`POST /api/skills/playground`) to accept an optional `scenario` field and append it to the generated verification prompt only when present, preserving backward compatibility. 
- Enhanced the UI to render returned `partialText` (model summary) and an expandable `result` JSON payload to aid debugging.

### Testing

- Ran `pnpm --dir web check`, which surfaced pre-existing unrelated TypeScript/svelte-check errors and therefore failed (these were not introduced by this change). 
- Launched the dev server with `pnpm --dir web dev --host 0.0.0.0 --port 6006` and performed manual smoke verification of the `/skills` route and playground dialog. 
- Captured a Playwright screenshot of the skills page to validate UI rendering (`artifacts/skills-page.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c7b2e4fac832e8d5bdb99d01e891b)