### PR TITLE
Fix web build failures in node config sync panel and API route

### DIFF
--- a/web/src/lib/components/node-detail-panel.svelte
+++ b/web/src/lib/components/node-detail-panel.svelte
@@ -337,10 +337,10 @@
               {/if}
 
               {#if configSyncState}
+                {@const syncStatus = getConfigSyncStatus(configSyncState)}
                 <div class="rounded-lg border border-border p-4 mb-3">
                   <div class="flex items-center justify-between mb-3">
                     <div class="text-xs font-medium text-foreground">Sync Status</div>
-                    {@const syncStatus = getConfigSyncStatus(configSyncState)}
                     <span class={`inline-flex items-center rounded-md px-2 py-1 text-[10px] font-medium ${syncStatus.badgeClass}`}>
                       {syncStatus.label}
                     </span>

--- a/web/src/routes/api/nodes/[id]/config-sync-state/+server.ts
+++ b/web/src/routes/api/nodes/[id]/config-sync-state/+server.ts
@@ -5,7 +5,7 @@
  * Authenticated via gateway API token or service role.
  */
 
-import { json, type RequestHandler } from "./$types";
+import { json, type RequestHandler } from "@sveltejs/kit";
 import { env } from "$env/dynamic/private";
 import { updateConfigSyncState } from "$lib/server/viber-nodes";
 


### PR DESCRIPTION
### Motivation

- The Svelte build failed due to an invalid placement of a `{@const}` tag inside `node-detail-panel.svelte`, causing a compile-time error.
- The web bundler failed to resolve a local `$types` import in the API route, preventing the `web` app from producing a production build.

### Description

- Move the `{@const syncStatus = getConfigSyncStatus(configSyncState)}` declaration so it is the immediate child of the `{#if configSyncState}` block in `web/src/lib/components/node-detail-panel.svelte` to satisfy Svelte syntax rules.
- Change the import in `web/src/routes/api/nodes/[id]/config-sync-state/+server.ts` to import `json` and `RequestHandler` from `@sveltejs/kit` instead of `./$types` to fix bundler resolution.

### Testing

- Ran `pnpm build:web` and the SvelteKit production build completed successfully.
- Ran `pnpm build` for the root package and the TypeScript/tsup build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c7df67f50832e949bcc1a193128ad)