### PR TITLE
docs: expand intent-driven onboarding and Viber Board details

### DIFF
--- a/docs/concepts/viber.md
+++ b/docs/concepts/viber.md
@@ -30,25 +30,65 @@ You:   "Go ahead"
 Viber: On it. You can watch in the terminal panel...
 ```
 
+## Intent-Driven Creation (Viber Board)
+
+In the web UI, the **New Viber** flow is intent-first and environment-aware:
+
+1. Pick an intent template (for example: _Build a Feature_, _Code Review_, _Railway Deploy Failures_)
+2. OpenViber pre-fills the task goal from the template
+3. OpenViber infers required skills from the intent
+4. OpenViber compares required skills against the selected node's currently available skills
+5. If a required skill is missing, the UI opens a guided prerequisite flow before launch
+6. Once required skills are ready, the task auto-launches with the selected intent body
+
+### How Required Skills Are Inferred
+
+OpenViber merges skill requirements from three sources (highest confidence first):
+
+1. `intent.skills` (explicit per-template list)
+2. A `skills:` section declared inside the intent body
+3. Keyword detection in the intent text (for skill-specific terms)
+
+This gives good defaults for built-in templates while still letting you create precise custom templates.
+
+### Guided Setup Before Launch
+
+When a selected node is active but a required skill is not ready on that node, OpenViber starts a proactive setup flow:
+
+- checks node availability
+- runs skill provisioning for supported skills
+- handles auth guidance when the skill needs external login
+- retries launch automatically when prerequisites become available
+
+If the node is offline, OpenViber asks you to bring it online before launching the task.
+
+### Where to Manage Intents
+
+You can manage built-in and custom intent templates in **Settings → Intents**:
+
+- create and edit custom templates
+- replicate built-in templates into editable user templates
+- keep intent instructions aligned with your team workflows
+
 ## What Makes a Viber
 
 A viber combines three elements that no chat-only AI has:
 
-| Element | What It Gives You |
-|---------|--------------------|
-| **Persona & Goals** | Role focus — not a generic assistant, but a specialist with clear objectives |
-| **Machine Runtime** | Real execution — terminal, browser, files, apps on your machine |
-| **Identity & Accounts** | Agency — acts on your behalf across GitHub, email, cloud services |
+| Element                 | What It Gives You                                                            |
+| ----------------------- | ---------------------------------------------------------------------------- |
+| **Persona & Goals**     | Role focus — not a generic assistant, but a specialist with clear objectives |
+| **Machine Runtime**     | Real execution — terminal, browser, files, apps on your machine              |
+| **Identity & Accounts** | Agency — acts on your behalf across GitHub, email, cloud services            |
 
 This is what separates vibers from chatbots: they don't just answer questions, they **do the work**.
 
 ## Working Modes
 
-| Mode | When to Use |
-|------|-------------|
-| **Always Ask** | Building trust — viber asks before each action |
-| **Viber Decides** | Daily work — viber acts within policy, escalates risky actions |
-| **Always Execute** | Overnight runs — maximum autonomy, intervene by exception |
+| Mode               | When to Use                                                    |
+| ------------------ | -------------------------------------------------------------- |
+| **Always Ask**     | Building trust — viber asks before each action                 |
+| **Viber Decides**  | Daily work — viber acts within policy, escalates risky actions |
+| **Always Execute** | Overnight runs — maximum autonomy, intervene by exception      |
 
 Start with "Always Ask" and graduate to "Viber Decides" as you build confidence.
 
@@ -72,7 +112,7 @@ A **Viber Node** is a single machine running the OpenViber runtime. It provides:
 
 ### Adding a Node
 
-From the OpenViber Board, click "Add Node" to generate a one-liner:
+From the OpenViber Board, click **Add Node** to generate a one-liner:
 
 ```bash
 npx openviber connect --token eyJub2RlIjoiYTFiMmMz...

--- a/docs/getting-started/onboarding.md
+++ b/docs/getting-started/onboarding.md
@@ -10,9 +10,33 @@ send tasks, and monitor your viber remotely.
 ### Step 1: Create a Viber Node on the Web
 
 1. Log in to [OpenViber Web](http://localhost:6006) (or your deployed URL)
-2. Go to **Vibers** → Click **"New Viber Node"**
-3. Give your viber a name
+2. Go to **Vibers** → Click **"Add Node"**
+3. Give your node a name
 4. Copy the generated command
+
+### Optional: Create a viber from an intent
+
+After the node is online, open **Vibers → New Viber** and choose an intent template (for example, _Build a Feature_ or _Code Review_).
+
+The launch flow is:
+
+1. Select an active node
+2. Select an intent template (or paste your own goal)
+3. OpenViber infers required skills from template metadata, `skills:` blocks, and keywords
+4. If the selected node is missing required skills, OpenViber starts guided provisioning before launch
+5. After prerequisites are ready, the task launches automatically with the selected intent body
+
+Supported proactive skill provisioning currently covers:
+
+- `cursor-agent`
+- `codex-cli`
+- `gemini-cli`
+- `github`
+- `gmail`
+- `railway`
+- `tmux` (terminal backing skill)
+
+You can manage templates in **Settings → Intents**.
 
 ### Step 2: Run the Onboard Command
 
@@ -23,6 +47,7 @@ npx openviber onboard --token <token>
 ```
 
 This will:
+
 - Install/update OpenViber
 - Create `~/.openviber/` configuration directory
 - Connect your machine to the web dashboard
@@ -93,14 +118,14 @@ After onboarding, your `~/.openviber/` directory looks like:
 
 ## Commands Reference
 
-| Command | Description |
-|---------|-------------|
-| `npx openviber onboard` | Set up standalone mode |
+| Command                             | Description              |
+| ----------------------------------- | ------------------------ |
+| `npx openviber onboard`             | Set up standalone mode   |
 | `npx openviber onboard --token <t>` | Connect to OpenViber Web |
-| `npx openviber start` | Start the viber daemon |
-| `npx openviber run "<task>"` | Run a one-off task |
-| `npx openviber chat` | Interactive chat mode |
-| `npx openviber status` | Check viber status |
+| `npx openviber start`               | Start the viber daemon   |
+| `npx openviber run "<task>"`        | Run a one-off task       |
+| `npx openviber chat`                | Interactive chat mode    |
+| `npx openviber status`              | Check viber status       |
 
 ---
 
@@ -109,6 +134,10 @@ After onboarding, your `~/.openviber/` directory looks like:
 **Token expired?** Create a new viber node on the web and run `npx openviber onboard --token` again.
 
 **Can't connect?** Make sure OpenViber Web is running. By default: `http://localhost:6006`
+
+**Intent launch says a skill is missing?** Keep the target node selected and use the guided setup dialog to provision prerequisites, then retry launch.
+
+**Node not selectable in New Viber?** Only active (connected) nodes can receive launches. Start your local daemon with `npx openviber start` and refresh the page.
 
 **Need to switch modes?** You can always re-run `npx openviber onboard --token <token>` to switch
 from standalone to connected mode.


### PR DESCRIPTION
### Motivation
- The previous onboarding and Viber Board docs were too brief about intent-driven flows and prerequisite handling, causing confusion about how intents map to skills and how launches are provisioned. 
- The goal is to document inference precedence, node-skill checks, guided provisioning, and where to manage intent templates so users can reliably create and launch vibers from intents.

### Description
- Expanded `docs/concepts/viber.md` to add a detailed **Intent-Driven Creation** walkthrough that covers skill inference precedence, node skill availability checks, guided prerequisite setup, offline-node handling, and intent management actions in `Settings → Intents`. 
- Expanded `docs/getting-started/onboarding.md` to include a concrete step-by-step post-onboarding intent launch flow, a list of currently supported proactive provisioning IDs (`cursor-agent`, `codex-cli`, `gemini-cli`, `github`, `gmail`, `railway`, `tmux`), and new troubleshooting guidance for missing-skill and inactive-node scenarios. 
- Reverted an earlier partial edit to `docs/concepts/skills.md` and confined the final changes to the two onboarding-related markdown files only. 

### Testing
- Ran `pnpm exec prettier --check docs/concepts/viber.md docs/getting-started/onboarding.md` which passed and confirmed consistent formatting. 
- Performed a local commit of the documentation updates and validated the modified files renderable and lint-free with Prettier checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c7cbe0368832e9d036c1b79bffcb5)