### PR TITLE
Add animated task step indicator and AI-generated task titles

### DIFF
--- a/web/src/lib/components/vibers/task-step-indicator.svelte
+++ b/web/src/lib/components/vibers/task-step-indicator.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+  import { onDestroy, onMount } from "svelte";
+
+  interface Props {
+    status: string;
+    archived?: boolean;
+  }
+
+  let { status, archived = false }: Props = $props();
+
+  const runningSteps = ["Thinking", "Planning", "Working"];
+  let phaseIndex = $state(0);
+  let phaseTimer: ReturnType<typeof setInterval> | null = null;
+
+  const normalizedStatus = $derived((status || "unknown").toLowerCase());
+  const stepText = $derived.by(() => {
+    if (archived) return "Archived";
+    if (normalizedStatus === "running" || normalizedStatus === "pending") {
+      return runningSteps[phaseIndex % runningSteps.length];
+    }
+    if (normalizedStatus === "completed") return "Completed";
+    if (normalizedStatus === "error") return "Needs attention";
+    if (normalizedStatus === "stopped") return "Stopped";
+    return "Queued";
+  });
+
+  const animated = $derived(
+    normalizedStatus === "running" || normalizedStatus === "pending",
+  );
+
+  onMount(() => {
+    phaseTimer = setInterval(() => {
+      phaseIndex += 1;
+    }, 1600);
+  });
+
+  onDestroy(() => {
+    if (phaseTimer) clearInterval(phaseTimer);
+  });
+</script>
+
+<p
+  class="mt-1.5 text-xs text-muted-foreground truncate {animated
+    ? 'task-step-animated'
+    : ''}"
+>
+  {stepText}
+  {#if animated}
+    <span class="task-step-dots" aria-hidden="true"></span>
+  {/if}
+</p>
+
+<style>
+  .task-step-animated {
+    color: color-mix(in oklab, var(--foreground) 72%, var(--muted-foreground));
+    animation: task-step-glow 1.6s ease-in-out infinite;
+  }
+
+  .task-step-dots::after {
+    content: "...";
+    display: inline-block;
+    width: 1.5em;
+    text-align: left;
+    animation: task-step-dots 1.2s steps(4, end) infinite;
+  }
+
+  @keyframes task-step-glow {
+    0%,
+    100% {
+      opacity: 0.72;
+    }
+
+    50% {
+      opacity: 1;
+    }
+  }
+
+  @keyframes task-step-dots {
+    0% {
+      width: 0;
+    }
+
+    100% {
+      width: 1.5em;
+    }
+  }
+</style>

--- a/web/src/lib/server/task-title.ts
+++ b/web/src/lib/server/task-title.ts
@@ -1,0 +1,86 @@
+import { env } from "$env/dynamic/private";
+
+const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
+const MAX_GOAL_PREVIEW_CHARS = 1200;
+
+/**
+ * Build a concise, user-facing task title from a raw goal message.
+ * Falls back to first non-empty line when no model is available.
+ */
+export async function summarizeTaskTitle(
+  goal: string,
+  preferredModel?: string,
+): Promise<string> {
+  const fallback = extractDisplayName(goal);
+  const apiKey = env.OPENROUTER_API_KEY;
+
+  if (!apiKey) return fallback;
+
+  try {
+    const response = await fetch(OPENROUTER_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+        "HTTP-Referer": "https://openviber.local",
+        "X-Title": "OpenViber task title summarizer",
+      },
+      body: JSON.stringify({
+        model: pickSummaryModel(preferredModel),
+        temperature: 0.2,
+        max_tokens: 40,
+        messages: [
+          {
+            role: "system",
+            content:
+              "You create short task titles for a task list UI. Reply with only the title. Keep it specific, actionable, and under 8 words.",
+          },
+          {
+            role: "user",
+            content: `Task request:\n${goal.slice(0, MAX_GOAL_PREVIEW_CHARS)}\n\nReturn only the title.`,
+          },
+        ],
+      }),
+    });
+
+    if (!response.ok) return fallback;
+
+    const payload = (await response.json()) as {
+      choices?: Array<{ message?: { content?: string } }>;
+    };
+
+    const content = payload.choices?.[0]?.message?.content?.trim();
+    if (!content) return fallback;
+
+    const sanitized = content
+      .replace(/^"|"$/g, "")
+      .replace(/[\r\n]+/g, " ")
+      .trim();
+
+    return sanitized ? limitWords(sanitized, 8) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+/** Extract a short display name from a potentially long goal text. */
+export function extractDisplayName(goal: string): string {
+  const firstLine = goal
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+
+  return firstLine || goal;
+}
+
+function limitWords(value: string, maxWords: number): string {
+  const words = value.split(/\s+/).filter(Boolean);
+  if (words.length <= maxWords) return value;
+  return `${words.slice(0, maxWords).join(" ")}…`;
+}
+
+function pickSummaryModel(preferredModel?: string): string {
+  const model = preferredModel?.trim();
+  if (model && model.includes("/")) return model;
+  return "openai/gpt-4o-mini";
+}

--- a/web/src/routes/(viberboard)/vibers/+page.svelte
+++ b/web/src/routes/(viberboard)/vibers/+page.svelte
@@ -23,6 +23,7 @@
     getVibersStore,
     type ViberListItem,
   } from "$lib/stores/vibers";
+  import TaskStepIndicator from "$lib/components/vibers/task-step-indicator.svelte";
 
   const vibersStore = getVibersStore();
   let hubConnected = $state(false);
@@ -202,6 +203,10 @@
                   <CardTitle class="text-sm font-medium leading-snug truncate">
                     {viber.goal || viber.id}
                   </CardTitle>
+                  <TaskStepIndicator
+                    status={viber.status}
+                    archived={Boolean(viber.archivedAt)}
+                  />
                   <CardDescription class="text-xs mt-1 truncate">
                     <Badge
                       variant="outline"

--- a/web/src/routes/api/vibers/+server.ts
+++ b/web/src/routes/api/vibers/+server.ts
@@ -10,18 +10,7 @@ import {
 import { getSettingsForUser } from "$lib/server/user-settings";
 import { supabaseRequest, toInFilter } from "$lib/server/supabase-rest";
 import { writeLog } from "$lib/server/logs";
-
-/**
- * Extract a short display name from a potentially long goal text.
- * Takes the first non-empty line and trims it.
- */
-function extractDisplayName(goal: string): string {
-  const firstLine = goal
-    .split("\n")
-    .map((l) => l.trim())
-    .find((l) => l.length > 0);
-  return firstLine || goal;
-}
+import { summarizeTaskTitle } from "$lib/server/task-title";
 
 // POST /api/vibers - Create a new viber on a node
 export const POST: RequestHandler = async ({ request, locals }) => {
@@ -116,7 +105,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
     // the first meaningful line from the goal as the display name.
     const displayName = typeof title === "string" && title.trim()
       ? title.trim()
-      : extractDisplayName(goal);
+      : await summarizeTaskTitle(goal, viberModel);
 
     if (locals.user?.id) {
       try {


### PR DESCRIPTION
### Motivation
- Surface a concise, human-friendly task title and show the current step beneath each task so users can see progress at-a-glance with lightweight text-style animations.
- Automatically produce meaningful display names for newly created tasks by summarizing the raw goal with an LLM when an explicit `title` is not supplied.

### Description
- Add a new Svelte component `TaskStepIndicator` at `web/src/lib/components/vibers/task-step-indicator.svelte` that cycles short step labels (e.g. `Thinking`, `Planning`, `Working`) and shows animated trailing dots when a viber is active.
- Render the `TaskStepIndicator` immediately below each task title on the tasks list page in `web/src/routes/(viberboard)/vibers/+page.svelte`.
- Add a server-side helper `summarizeTaskTitle` in `web/src/lib/server/task-title.ts` that calls OpenRouter (controlled via `OPENROUTER_API_KEY`) to produce concise task-list titles, with a safe fallback to the first non-empty line of the goal.
- Update `POST /api/vibers` in `web/src/routes/api/vibers/+server.ts` to use `summarizeTaskTitle(goal, model)` when `title` is not provided so persisted and list-displayed names are more meaningful.

### Testing
- Ran `pnpm --dir web check`, which reported pre-existing unrelated type errors in other files and therefore failed; no new type errors attributable to these changes were introduced during investigation.
- Launched the web dev server with E2E mode (`cd web && E2E_TEST_MODE=true pnpm dev`) and verified the test session endpoint via `curl http://localhost:6006/auth/test-session` which returned the expected E2E test-mode response.
- Executed a Playwright-based UI script that mocked `GET /api/vibers` and `GET /api/hub`, navigated to `/vibers`, and produced a screenshot showing the new animated step indicator (artifact captured successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c86e0a564832ea60bfd44f5e3e3c0)