### PR TITLE
perf: parallelize channel shutdown in ChannelManager

### DIFF
--- a/src/channels/manager.ts
+++ b/src/channels/manager.ts
@@ -67,17 +67,21 @@ export class ChannelManager extends EventEmitter {
   }
 
   /**
-   * Stop all registered channels
+   * Stop all registered channels in parallel
    */
   async stopAll(): Promise<void> {
-    for (const [id, channel] of this.channels) {
-      try {
-        await channel.stop();
-        console.log(`[ChannelManager] Stopped channel: ${id}`);
-      } catch (error) {
-        console.error(`[ChannelManager] Failed to stop channel ${id}:`, error);
+    const stopPromises = Array.from(this.channels.entries()).map(
+      async ([id, channel]) => {
+        try {
+          await channel.stop();
+          console.log(`[ChannelManager] Stopped channel: ${id}`);
+        } catch (error) {
+          console.error(`[ChannelManager] Failed to stop channel ${id}:`, error);
+        }
       }
-    }
+    );
+
+    await Promise.all(stopPromises);
   }
 
   /**


### PR DESCRIPTION
Optimizes the `stopAll` method in `ChannelManager` to stop all registered channels in parallel using `Promise.all`. This significantly reduces the total shutdown time from the sum of all channel shutdown times to approximately the time of the longest single shutdown.

Preserves existing error handling and logging for each channel.