### PR TITLE
Refactor skill registration to be explicit

### DIFF
--- a/docs/concepts/skills.md
+++ b/docs/concepts/skills.md
@@ -144,7 +144,7 @@ Skills are discovered from multiple paths, in priority order:
 
 ### Pre-registration
 
-In bundled builds where dynamic import of `.ts` files isn't possible, skills pre-register their tools at startup via `preRegisterTools()`. This happens automatically when `src/skills/index.ts` is imported.
+In bundled builds where dynamic import of `.ts` files isn't possible, skills pre-register their tools at startup via `preRegisterTools()`. The application entry point must call `registerDefaultSkills()` from `src/skills/index.ts` to ensure these tools are available.
 
 ## Built-in Skills
 

--- a/scripts/verify-skills.ts
+++ b/scripts/verify-skills.ts
@@ -16,8 +16,10 @@
  */
 
 import { defaultRegistry } from "../src/skills/registry";
+import { registerDefaultSkills } from "../src/skills";
+
 // Trigger pre-registration of skill tools
-import "../src/skills";
+registerDefaultSkills();
 
 async function main() {
   const runCursor = process.argv.includes("--cursor");

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -10,6 +10,9 @@ export const runCommand = new Command("run")
     const { loadOpenViberEnv } = await import("../auth");
     await loadOpenViberEnv();
 
+    const { registerDefaultSkills } = await import("../../skills");
+    registerDefaultSkills();
+
     const { runTask } = await import("../../daemon/runtime");
 
     console.log(`[Viber] Running task: ${goal}`);

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -33,7 +33,8 @@ export const startCommand = new Command("start")
     const { ViberController } = await import("../../daemon/controller");
 
     // Import skills module to trigger pre-registration of skill tools
-    await import("../../skills");
+    const { registerDefaultSkills } = await import("../../skills");
+    registerDefaultSkills();
 
     // Get or generate viber ID
     const viberId = await getViberId();

--- a/src/skills/codex-cli.integration.test.ts
+++ b/src/skills/codex-cli.integration.test.ts
@@ -9,9 +9,10 @@ import { describe, it, expect, beforeAll } from "vitest";
 import { defaultRegistry } from "./registry";
 import { Agent } from "../viber/agent";
 import { getTools as getCodexCliTools } from "./codex-cli";
+import { registerDefaultSkills } from "./index";
 
 // Trigger pre-registration so getTools("codex-cli") returns tools
-import "./index";
+registerDefaultSkills();
 
 beforeAll(async () => {
   await defaultRegistry.loadAll();

--- a/src/skills/cursor-agent.integration.test.ts
+++ b/src/skills/cursor-agent.integration.test.ts
@@ -10,9 +10,10 @@ import { describe, it, expect, beforeAll } from "vitest";
 import { defaultRegistry } from "./registry";
 import { Agent } from "../viber/agent";
 import { getTools as getCursorAgentTools } from "./cursor-agent";
+import { registerDefaultSkills } from "./index";
 
 // Trigger pre-registration so getTools("cursor-agent") returns tools
-import "./index";
+registerDefaultSkills();
 
 beforeAll(async () => {
   await defaultRegistry.loadAll();

--- a/src/skills/index.ts
+++ b/src/skills/index.ts
@@ -30,6 +30,3 @@ export function registerDefaultSkills() {
   defaultRegistry.preRegisterTools("skill-playground", getPlaygroundTools());
 }
 
-// Auto-register on import
-registerDefaultSkills();
-

--- a/src/viber/agent.ts
+++ b/src/viber/agent.ts
@@ -34,7 +34,6 @@ export interface AgentResponse {
  * No subclasses needed - behavior is entirely config-driven
  */
 import { defaultRegistry } from "../skills/registry";
-import "../skills"; // trigger registerDefaultSkills() side-effect
 
 /**
  * Config-driven Agent implementation


### PR DESCRIPTION
This change removes the side effect from `src/skills/index.ts` where default skills were automatically registered when the module was imported. This improves code health by making module initialization explicit and predictable.

Key changes:
- `src/skills/index.ts`: Removed the top-level `registerDefaultSkills()` call.
- `src/cli/commands/start.ts`: Added explicit `registerDefaultSkills()` call.
- `src/cli/commands/run.ts`: Added explicit `registerDefaultSkills()` call.
- `scripts/verify-skills.ts`: Added explicit `registerDefaultSkills()` call.
- `src/viber/agent.ts`: Removed unnecessary import of `src/skills`.
- `docs/concepts/skills.md`: Updated documentation to reflect the new manual registration requirement.
- Updated integration tests to explicitly register skills.

Verified by running `src/skills/cursor-agent.integration.test.ts` and `src/skills/codex-cli.integration.test.ts`, and the full test suite.

---
*PR created automatically by Jules for task [12029292165867412320](https://jules.google.com/task/12029292165867412320) started by @hughlv*