### PR TITLE
Implement MCP server configuration loading

### DIFF
--- a/src/viber/config.ts
+++ b/src/viber/config.ts
@@ -73,6 +73,32 @@ export interface ViberConfig {
   createServiceRoleClient?: () => any;
 }
 
+/**
+ * MCP Server Configuration
+ */
+export interface McpServerConfig {
+  name: string;
+  description?: string;
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+  require_approval?: string[];
+}
+
+/**
+ * Global Configuration (config.yaml)
+ */
+export interface GlobalConfig {
+  daemon?: any;
+  defaults?: any;
+  providers?: Record<string, any>;
+  budget?: any;
+  channels?: Record<string, any>;
+  gateway?: any;
+  security?: any;
+  mcp_servers?: McpServerConfig[];
+}
+
 let config: ViberConfig | null = null;
 
 /**
@@ -123,6 +149,20 @@ export async function loadAgentConfig(agentId: string): Promise<AgentConfig | nu
     const config = yaml.parse(content) as AgentConfig;
     return { ...config, id: agentId };
   } catch (error) {
+    return null;
+  }
+}
+
+/**
+ * Load global configuration from ~/.openviber/config.yaml
+ */
+export async function loadGlobalConfig(): Promise<GlobalConfig | null> {
+  const configPath = path.join(os.homedir(), ".openviber", "config.yaml");
+  try {
+    const content = await fs.readFile(configPath, "utf-8");
+    return yaml.parse(content) as GlobalConfig;
+  } catch (error) {
+    // Return null if config doesn't exist or is invalid
     return null;
   }
 }

--- a/src/viber/tool.test.ts
+++ b/src/viber/tool.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { buildToolMap } from './tool';
+import * as config from './config';
+
+// Mock loadGlobalConfig
+vi.mock('./config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./config')>();
+  return {
+    ...actual,
+    loadGlobalConfig: vi.fn(),
+  };
+});
+
+describe('buildToolMap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should identify MCP tools from config', async () => {
+    // Mock config to return an MCP server
+    vi.mocked(config.loadGlobalConfig).mockResolvedValue({
+      mcp_servers: [
+        {
+          name: 'github',
+          command: 'npx',
+          args: []
+        }
+      ]
+    });
+
+    // Mock console.warn to suppress expected output
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // Call buildToolMap with 'github'
+    await buildToolMap(['github']);
+
+    // Check if it tried to load MCP client (by checking the warning message)
+    // This confirms it went down the MCP path
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('MCP client creation not implemented for: github')
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it('should treat unknown tools as custom tools (and fail to find them)', async () => {
+    // Mock config to return NO MCP servers
+    vi.mocked(config.loadGlobalConfig).mockResolvedValue({});
+
+    // Mock console.warn
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // Call buildToolMap with 'github'
+    await buildToolMap(['github']);
+
+    // Check if it treated it as a custom tool (which is not found)
+    // This confirms it went down the custom tool path
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Tool not found: github')
+    );
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/viber/tool.ts
+++ b/src/viber/tool.ts
@@ -6,6 +6,7 @@
  */
 
 import { z } from "zod";
+import { loadGlobalConfig } from "./config";
 
 // Core tool interface that AI SDK expects
 export interface CoreTool {
@@ -48,7 +49,8 @@ export async function buildToolMap(
 
   // Load MCP server configurations to determine tool types
   // dataStore usage removed - simplified for now
-  const mcpServers: any[] = []; // TODO: Add logic to load MCP config from config.ts if needed
+  const globalConfig = await loadGlobalConfig();
+  const mcpServers: any[] = globalConfig?.mcp_servers?.map((s) => ({ ...s, id: s.name })) || [];
   const mcpServerIds = new Set(mcpServers.map((s: any) => s.id));
 
   // Separate custom tools and MCP tools


### PR DESCRIPTION
Implemented the loading of MCP server configurations from `~/.openviber/config.yaml` to address the code health issue in `src/viber/tool.ts`.

Details:
- Defined `McpServerConfig` and `GlobalConfig` interfaces in `src/viber/config.ts` matching the documentation schema.
- Implemented `loadGlobalConfig` to read and parse the global YAML configuration file.
- Updated `src/viber/tool.ts` to call `loadGlobalConfig` and populate `mcpServers` dynamically, ensuring MCP tools are correctly identified and processed by `buildToolMap`.
- Added unit tests in `src/viber/tool.test.ts` to verify that configured MCP servers are correctly identified and non-configured tools are treated as custom tools.


---
*PR created automatically by Jules for task [7307171236854249123](https://jules.google.com/task/7307171236854249123) started by @hughlv*