### PR TITLE
feat: make channel capabilities first-class and generate capability matrix

### DIFF
--- a/docs/design/architecture-overview.md
+++ b/docs/design/architecture-overview.md
@@ -1,0 +1,55 @@
+---
+title: "Architecture Overview"
+description: "A concise, visual overview of OpenViber components and boundaries"
+---
+
+# OpenViber Architecture Overview
+
+This page is a quick map of the system. For detailed behavior and contracts, follow the links in [Detailed design docs](#detailed-design-docs).
+
+## Runtime topology
+
+```mermaid
+flowchart LR
+    User[Operator]
+    Web[OpenViber Board\nweb/]
+    Gateway[Gateway\nsrc/gateway + src/channels]
+    Daemon[Daemon Runtime\nsrc/daemon]
+    Viber[Viber Core\nsrc/viber]
+    Tools[Tools + Skills\nsrc/tools + src/skills]
+    State[(~/.openviber)]
+    Spaces[(workspace repos / files)]
+
+    User --> Web
+    Web <--> Gateway
+    Gateway <--> Daemon
+    Daemon --> Viber
+    Viber --> Tools
+    Daemon <--> State
+    Tools <--> Spaces
+```
+
+## Layer boundaries (summary)
+
+- `web/`: UI only; communicates via API/WebSocket boundaries.
+- `src/channels` and `src/gateway`: transport adapters and routing.
+- `src/daemon`: orchestration, task lifecycle, and runtime coordination.
+- `src/viber`: planning/execution behavior and agent-level loop.
+- `src/tools` and `src/skills`: capability surfaces used by vibers.
+- `~/.openviber`: durable runtime state and personalization.
+
+## Detailed design docs
+
+- `docs/design/viber.md`
+- `docs/design/communication.md`
+- `docs/design/protocol.md`
+- `docs/design/task-lifecycle.md`
+- `docs/design/context-management.md`
+- `docs/design/memory.md`
+- `docs/design/personalization.md`
+- `docs/design/mcp-integration.md`
+- `docs/design/streaming.md`
+- `docs/design/error-handling.md`
+- `docs/design/security.md`
+- `docs/design/environments-and-threads.md`
+- `docs/design/polyglot-integration-contract.md`

--- a/docs/design/polyglot-integration-contract.md
+++ b/docs/design/polyglot-integration-contract.md
@@ -1,0 +1,156 @@
+---
+title: "Polyglot Integration Contract"
+description: "Stable contracts for integrating non-TypeScript workers/tools into OpenViber"
+---
+
+# Polyglot Integration Contract
+
+This document defines the minimum contracts required when integrating non-TypeScript components (e.g., Python workers, external executors, or sidecar services) into OpenViber.
+
+> Goal: keep OpenViber's current architecture elegance (clear boundaries, deterministic behavior, and typed interfaces) while enabling polyglot runtime extensions.
+
+## 1) Scope and boundaries
+
+Polyglot components are treated as **edge adapters**, not core orchestrators.
+
+- Core orchestration remains in `src/daemon` and `src/viber`.
+- Polyglot services must communicate through explicit protocol boundaries.
+- No direct cross-runtime shared mutable state.
+
+## 2) Transport contract
+
+Allowed transports:
+
+- Local process stdio (preferred for tool-style integrations)
+- HTTP/JSON (for sidecar services)
+- WebSocket (for streaming/event-driven integrations)
+
+Requirements:
+
+- UTF-8 encoded payloads.
+- Explicit request/response correlation via `requestId`.
+- Each response includes `status` (`ok` | `error`).
+
+Example envelope:
+
+```json
+{
+  "requestId": "req_123",
+  "status": "ok",
+  "data": { "result": "..." },
+  "error": null
+}
+```
+
+## 3) Event schema contract
+
+All event streams must use a normalized event envelope:
+
+```json
+{
+  "eventId": "evt_123",
+  "requestId": "req_123",
+  "timestamp": "2026-02-12T12:34:56.000Z",
+  "type": "text-delta",
+  "payload": {}
+}
+```
+
+Rules:
+
+- `eventId` must be unique per stream.
+- `timestamp` must be ISO-8601 UTC.
+- `type` should map to OpenViber event semantics (e.g., `text-delta`, `tool-call`, `tool-result`, `state-change`, `error`, `done`).
+- Event ordering must be preserved per `requestId`.
+
+## 4) Tool contract
+
+For externally executed tools:
+
+- Input schema and output schema must be explicit and versioned.
+- Tool calls must be deterministic for the same input and context unless marked non-deterministic.
+- Side effects must be declared (`filesystem`, `network`, `external-api`, `process`).
+
+Minimum metadata:
+
+```json
+{
+  "name": "tool-name",
+  "version": "1.0.0",
+  "inputSchema": {},
+  "outputSchema": {},
+  "sideEffects": ["filesystem"]
+}
+```
+
+## 5) Retry and idempotency
+
+- Retries are opt-in and policy-driven.
+- Integrations must support idempotency keys for mutation operations.
+- Timeout defaults must be explicit and documented.
+
+Recommended baseline:
+
+- Timeout: 30s default, integration-specific override allowed.
+- Retries: max 2 for transient failures.
+- Backoff: exponential with jitter.
+
+## 6) Error contract
+
+Errors must be structured:
+
+```json
+{
+  "status": "error",
+  "error": {
+    "code": "UPSTREAM_TIMEOUT",
+    "message": "...",
+    "retryable": true,
+    "details": {}
+  }
+}
+```
+
+Rules:
+
+- `code` is stable and machine-consumable.
+- `retryable` must be present.
+- Sensitive details must be redacted.
+
+## 7) Security and trust boundaries
+
+- Principle of least privilege for credentials and filesystem scope.
+- Secrets are injected via environment/runtime secret store, never hardcoded.
+- All external requests should use allowlisted domains where feasible.
+- Logs must avoid secret leakage.
+
+## 8) Observability
+
+Every integration should emit:
+
+- `requestId`, `integrationName`, `operation`, `durationMs`, `status`.
+- Error counters by `error.code`.
+- Optional tracing spans where supported.
+
+## 9) Versioning and compatibility
+
+- Contract versions must be semver-like and explicit.
+- Breaking changes require a new version and migration notes.
+- During migration windows, support previous contract version when feasible.
+
+## 10) Adoption checklist
+
+When introducing a polyglot integration:
+
+1. Define contract schema and version.
+2. Add conformance tests for envelope, ordering, and errors.
+3. Document retries/timeouts/idempotency behavior.
+4. Validate security and secret handling.
+5. Add operational runbook entries.
+
+## Related docs
+
+- `docs/design/protocol.md`
+- `docs/design/streaming.md`
+- `docs/design/error-handling.md`
+- `docs/design/security.md`

--- a/docs/guides/contribution-golden-path.md
+++ b/docs/guides/contribution-golden-path.md
@@ -1,0 +1,56 @@
+# Contribution Golden Paths
+
+This guide provides task-oriented contributor checklists for extending OpenViber while preserving architecture boundaries and code quality.
+
+## Add a new channel
+
+1. Define config and types in `src/channels/channel.ts`.
+2. Implement the channel class in `src/channels/<name>.ts`.
+3. Register the factory in `src/channels/builtin.ts`.
+4. Ensure bootstrap/env config mapping in `src/channels/config.ts` if needed.
+5. Add focused tests near the implementation (unit first, then integration if routing behavior changes).
+6. Update docs:
+   - `docs/reference/channel-capability-matrix.md`
+   - user-facing config docs (if new env vars/options are added)
+
+**Validation checklist**
+
+- `pnpm typecheck`
+- `pnpm test:run -- src/channels`
+- `pnpm test:run` (if shared channel manager behavior changed)
+
+## Add a new skill
+
+1. Create `src/skills/<skill-id>/index.ts`.
+2. Add `src/skills/<skill-id>/SKILL.md` with clear usage boundaries.
+3. Register skill metadata in `src/skills/registry.ts` (or the active registry wiring path).
+4. Add tests in `src/skills/*.test.ts` or `*.integration.test.ts` as appropriate.
+5. Run skills verification scripts and fix any metadata/packaging issues.
+
+**Validation checklist**
+
+- `pnpm typecheck`
+- `pnpm test:run -- src/skills`
+- `pnpm verify:skills`
+
+## Add a new tool
+
+1. Implement the tool in `src/tools/<tool>.ts`.
+2. Export/register through `src/tools/index.ts` and any runtime wiring points.
+3. Ensure tool input/output shape is explicit and stable.
+4. Add/update tests (`src/tools/<tool>.test.ts`).
+5. Update docs in `docs/concepts/tools.md` if tool contract changes.
+
+**Validation checklist**
+
+- `pnpm typecheck`
+- `pnpm test:run -- src/tools`
+- `pnpm test:run` (if shared base-tool behavior changed)
+
+## Architecture boundary guardrail
+
+Run:
+
+- `pnpm verify:architecture`
+
+This check catches forbidden cross-layer imports that make the codebase harder to reason about.

--- a/docs/reference/channel-capability-matrix.md
+++ b/docs/reference/channel-capability-matrix.md
@@ -1,0 +1,16 @@
+# Channel Capability Matrix
+
+This matrix is generated from built-in channel registry metadata. Run `pnpm docs:channels` after capability updates.
+
+| Channel | Display name | Transport | Inbound attachments | Auth summary | Controls | Production readiness |
+|---|---|---|---|---|---|---|
+| `dingtalk` | DingTalk | `webhook` | no | appKey + appSecret (+ optional robotCode) | — | ready |
+| `discord` | Discord | `websocket` | yes | botToken (+ optional appId) | allowGuildIds, allowChannelIds, allowUserIds, requireMention, replyMode | ready |
+| `feishu` | Feishu | `websocket` | yes | appId + appSecret (+ optional verification/encryption keys) | allowGroupMessages, requireMention | ready |
+| `web` | Web | `sse` | yes | session-based web app context | — | ready |
+| `wecom` | WeCom | `webhook` | no | corpId + agentId + secret + token + aesKey | — | ready |
+
+## Source
+
+- `src/channels/registry.ts`
+- `src/channels/builtin.ts`

--- a/docs/reference/openviber-vs-nanobot.md
+++ b/docs/reference/openviber-vs-nanobot.md
@@ -1,0 +1,87 @@
+# OpenViber vs NanoBot: Project Structure & Architecture Comparison
+
+Date: 2026-02-12
+
+## Method
+
+I compared:
+
+- OpenViber repository structure and architecture docs in this repo.
+- NanoBot (`HKUDS/nanobot`) at `main` (cloned locally to `/tmp/nanobot`).
+
+Commands used:
+
+- `rg --files | head -n 200` (OpenViber)
+- `cat package.json` (OpenViber)
+- `git clone --depth 1 https://github.com/HKUDS/nanobot /tmp/nanobot`
+- `cd /tmp/nanobot && rg --files | head -n 200`
+- `cd /tmp/nanobot && sed -n '1,240p' README.md`
+- `cd /tmp/nanobot && sed -n '1,220p' COMMUNICATION.md`
+
+## High-level verdict
+
+OpenViber is **more architecturally explicit and maintainable** than NanoBot in several key ways:
+
+1. **Architecture as first-class docs**: OpenViber has a dedicated `docs/design/` set with specific specs (protocol, task lifecycle, context, memory, streaming, security, error handling, etc.), which creates stronger design coherence and onboarding clarity.
+2. **Runtime boundary clarity**: OpenViber separates `cli`, `daemon`, `channels`, `skills`, `tools`, `viber`, and `web` clearly.
+3. **Typed consistency in core runtime**: OpenViber is TypeScript-first end-to-end (core + web), reducing language/context switching overhead.
+4. **Validation and test posture**: OpenViber includes broad test coverage across modules and explicit verification scripts (`test:run`, `typecheck`, `verify:skills`).
+
+NanoBot is still strong in pragmatic breadth (many channels, Python + TS bridge, practical workspace conventions), but its architecture is less explicitly codified and less consistently layered in documentation.
+
+## Side-by-side comparison
+
+| Dimension | OpenViber | NanoBot | Assessment |
+|---|---|---|---|
+| Architectural docs | Rich design docs set under `docs/design/` with multiple focused specs | Fewer architecture docs (`README.md`, `COMMUNICATION.md`) | **OpenViber leads** in architectural explicitness |
+| Layering | Distinct top-level runtime concerns (`src/daemon`, `src/channels`, `src/tools`, `src/skills`, `src/viber`, `web`) | Python core + separate TS bridge; good modularity but less documented boundary contracts | **OpenViber leads** in visible layering discipline |
+| Language consistency | TS across core + web | Python core + TypeScript bridge | Depends on team, but **OpenViber is more uniform** |
+| Test/verification ergonomics | Vitest, typecheck, dedicated skills verification scripts | Python project structure with fewer obvious project-wide validation commands in top-level docs | **OpenViber leads** in explicit quality gates |
+| Multi-channel capability | Multiple channels plus web app | Very broad channel support in Python | **Comparable**, NanoBot has strong breadth |
+| Personalization/memory model | Explicit three-file personalization pattern and runtime conventions | Workspace files and memory docs present, but less formalized lifecycle docs | **OpenViber leads** in formalization |
+
+## Where OpenViber can still improve
+
+OpenViber is cleaner overall, but there are areas where NanoBot-style pragmatism suggests useful improvements:
+
+1. **Single architecture overview artifact**
+   - Add one concise visual architecture diagram (like NanoBot's architecture image) that links to detailed docs.
+   - Why: improves first-time comprehension before deep reading.
+
+2. **Channel capability matrix in docs**
+   - Create a table listing channel status, auth mode, media support, and reliability expectations.
+   - Why: operational clarity for adopters.
+
+3. **Cross-language integration story (if future polyglot)**
+   - If OpenViber adds polyglot workers/tools, define strict interface contracts early (events, tool schema, retries).
+   - Why: preserve current elegance while scaling capability breadth.
+
+4. **Architecture fitness checks**
+   - Add lightweight CI checks for forbidden imports across layers (e.g., `web` cannot import daemon internals).
+   - Why: enforce boundaries mechanically, not just culturally.
+
+5. **Developer “golden path” docs**
+   - Add one task-focused guide: “add a channel”, “add a skill”, “add a tool” with test checklist templates.
+   - Why: lower contributor variance, keep coding style consistent as team grows.
+
+## Conclusion
+
+If the bar is architectural elegance + coding taste (clarity of layers, explicit contracts, and maintainability signals), **OpenViber is ahead**.
+
+If the bar is immediate channel breadth and pragmatic integration footprint, NanoBot is competitive and occasionally stronger.
+
+The best next move is not a rewrite: keep OpenViber’s current architecture, then add the five improvements above to compound its lead.
+
+
+## Progress on suggested improvements
+
+Implemented in this repository:
+
+1. ✅ Added a concise architecture overview document with a visual topology map: `docs/design/architecture-overview.md`.
+2. ✅ Added a channel capability matrix: `docs/reference/channel-capability-matrix.md`.
+3. ✅ Added contributor golden-path docs for adding channels/skills/tools: `docs/guides/contribution-golden-path.md`.
+4. ✅ Added architecture fitness checks via `scripts/verify-architecture.ts` and `pnpm verify:architecture`.
+
+Still recommended for future evolution:
+
+5. ✅ Added a cross-language integration contract document: `docs/design/polyglot-integration-contract.md`.

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "test": "vitest",
     "test:run": "vitest run",
     "preview:web": "cd web && pnpm preview",
-    "verify:skills": "tsx scripts/verify-skills.ts"
+    "verify:skills": "tsx scripts/verify-skills.ts",
+    "verify:architecture": "tsx scripts/verify-architecture.ts",
+    "docs:channels": "tsx scripts/generate-channel-capability-matrix.ts"
   },
   "keywords": [
     "multi-agent",

--- a/scripts/generate-channel-capability-matrix.ts
+++ b/scripts/generate-channel-capability-matrix.ts
@@ -1,0 +1,50 @@
+import fs from "fs";
+import path from "path";
+import { registerBuiltinChannels } from "../src/channels/builtin";
+import { channelRegistry } from "../src/channels/registry";
+
+const OUTPUT_PATH = path.join("docs", "reference", "channel-capability-matrix.md");
+
+/**
+ * Render markdown table content from registered channel capabilities.
+ */
+function buildMarkdown(): string {
+  registerBuiltinChannels();
+  const channels = channelRegistry
+    .listCapabilities()
+    .sort((a, b) => a.id.localeCompare(b.id));
+
+  const lines: string[] = [];
+  lines.push("# Channel Capability Matrix");
+  lines.push("");
+  lines.push(
+    "This matrix is generated from built-in channel registry metadata. Run `pnpm docs:channels` after capability updates.",
+  );
+  lines.push("");
+  lines.push(
+    "| Channel | Display name | Transport | Inbound attachments | Auth summary | Controls | Production readiness |",
+  );
+  lines.push("|---|---|---|---|---|---|---|");
+
+  for (const channel of channels) {
+    lines.push(
+      `| \`${channel.id}\` | ${channel.displayName} | \`${channel.capabilities.transport}\` | ${channel.capabilities.supportsInboundAttachments ? "yes" : "no"} | ${channel.capabilities.auth} | ${(channel.capabilities.controls ?? []).join(", ") || "—"} | ${channel.capabilities.productionReadiness} |`,
+    );
+  }
+
+  lines.push("");
+  lines.push("## Source");
+  lines.push("");
+  lines.push("- `src/channels/registry.ts`");
+  lines.push("- `src/channels/builtin.ts`");
+
+  return `${lines.join("\n")}\n`;
+}
+
+function main(): void {
+  const markdown = buildMarkdown();
+  fs.writeFileSync(OUTPUT_PATH, markdown, "utf8");
+  console.log(`Wrote ${OUTPUT_PATH}`);
+}
+
+main();

--- a/scripts/verify-architecture.ts
+++ b/scripts/verify-architecture.ts
@@ -1,0 +1,108 @@
+import fs from "fs";
+import path from "path";
+
+interface BoundaryRule {
+  fromPrefix: string;
+  forbiddenPrefixes: string[];
+  reason: string;
+}
+
+const RULES: BoundaryRule[] = [
+  {
+    fromPrefix: "src/viber/",
+    forbiddenPrefixes: ["src/channels/", "src/gateway/", "web/"],
+    reason: "viber core should not depend on transport/UI layers",
+  },
+  {
+    fromPrefix: "src/tools/",
+    forbiddenPrefixes: ["src/channels/", "web/"],
+    reason: "tools should remain runtime-capability focused",
+  },
+  {
+    fromPrefix: "src/channels/",
+    forbiddenPrefixes: ["web/"],
+    reason: "channel adapters should not import web app code",
+  },
+  {
+    fromPrefix: "src/daemon/",
+    forbiddenPrefixes: ["web/"],
+    reason: "daemon runtime should not import web app code directly",
+  },
+];
+
+const SOURCE_ROOTS = ["src", "web/src"];
+const IMPORT_RE = /^\s*import(?:\s+type)?[\s\S]*?from\s+["'](.+)["'];?\s*$/gm;
+
+function walk(dir: string, files: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name === "dist" || entry.name.startsWith(".")) {
+      continue;
+    }
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(fullPath, files);
+      continue;
+    }
+    if (fullPath.endsWith(".ts") || fullPath.endsWith(".tsx") || fullPath.endsWith(".svelte")) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function toPosix(value: string): string {
+  return value.split(path.sep).join("/");
+}
+
+function resolveImportTarget(filePath: string, importPath: string): string | null {
+  if (importPath.startsWith(".") || importPath.startsWith("..")) {
+    return toPosix(path.normalize(path.join(path.dirname(filePath), importPath)));
+  }
+  return null;
+}
+
+function isUnderPrefix(filePath: string, prefix: string): boolean {
+  return filePath.startsWith(prefix);
+}
+
+function main(): void {
+  const files = SOURCE_ROOTS.flatMap((root) => (fs.existsSync(root) ? walk(root) : []));
+  const violations: string[] = [];
+
+  for (const file of files) {
+    const filePosix = toPosix(file);
+    const activeRules = RULES.filter((rule) => isUnderPrefix(filePosix, rule.fromPrefix));
+    if (activeRules.length === 0) continue;
+
+    const content = fs.readFileSync(file, "utf8");
+    const matches = content.matchAll(IMPORT_RE);
+
+    for (const match of matches) {
+      const importPath = match[1];
+      const target = resolveImportTarget(filePosix, importPath);
+      if (!target) continue;
+
+      for (const rule of activeRules) {
+        for (const forbiddenPrefix of rule.forbiddenPrefixes) {
+          if (target.includes(`/${forbiddenPrefix}`) || target.startsWith(forbiddenPrefix)) {
+            violations.push(
+              `${filePosix} imports "${importPath}" -> ${target} (forbidden: ${forbiddenPrefix}; ${rule.reason})`,
+            );
+          }
+        }
+      }
+    }
+  }
+
+  if (violations.length > 0) {
+    console.error("Architecture boundary check failed:\n");
+    for (const violation of violations) {
+      console.error(`- ${violation}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(`Architecture boundary check passed (${files.length} files scanned).`);
+}
+
+main();

--- a/src/channels/builtin.ts
+++ b/src/channels/builtin.ts
@@ -15,6 +15,12 @@ export function registerBuiltinChannels(): void {
       id: "dingtalk",
       displayName: "DingTalk",
       description: "DingTalk enterprise bot integration",
+      capabilities: {
+        transport: "webhook",
+        supportsInboundAttachments: false,
+        auth: "appKey + appSecret (+ optional robotCode)",
+        productionReadiness: "ready",
+      },
       create: (config, context) => new DingTalkChannel(config as any, context),
     });
   }
@@ -24,6 +30,12 @@ export function registerBuiltinChannels(): void {
       id: "wecom",
       displayName: "WeCom",
       description: "WeCom (WeChat Work) enterprise integration",
+      capabilities: {
+        transport: "webhook",
+        supportsInboundAttachments: false,
+        auth: "corpId + agentId + secret + token + aesKey",
+        productionReadiness: "ready",
+      },
       create: (config, context) => new WeComChannel(config as any, context),
     });
   }
@@ -33,6 +45,12 @@ export function registerBuiltinChannels(): void {
       id: "web",
       displayName: "Web",
       description: "Local web channel (SSE)",
+      capabilities: {
+        transport: "sse",
+        supportsInboundAttachments: true,
+        auth: "session-based web app context",
+        productionReadiness: "ready",
+      },
       create: (config, _context) => new WebChannel(config as any),
     });
   }
@@ -42,6 +60,19 @@ export function registerBuiltinChannels(): void {
       id: "discord",
       displayName: "Discord",
       description: "Discord bot integration via gateway",
+      capabilities: {
+        transport: "websocket",
+        supportsInboundAttachments: true,
+        auth: "botToken (+ optional appId)",
+        controls: [
+          "allowGuildIds",
+          "allowChannelIds",
+          "allowUserIds",
+          "requireMention",
+          "replyMode",
+        ],
+        productionReadiness: "ready",
+      },
       create: (config, context) => new DiscordChannel(config as any, context),
     });
   }
@@ -51,6 +82,13 @@ export function registerBuiltinChannels(): void {
       id: "feishu",
       displayName: "Feishu",
       description: "Feishu/Lark bot integration",
+      capabilities: {
+        transport: "websocket",
+        supportsInboundAttachments: true,
+        auth: "appId + appSecret (+ optional verification/encryption keys)",
+        controls: ["allowGroupMessages", "requireMention"],
+        productionReadiness: "ready",
+      },
       create: (config, context) => new FeishuChannel(config as any, context),
     });
   }

--- a/src/channels/registry.test.ts
+++ b/src/channels/registry.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { registerBuiltinChannels } from "./builtin";
+import { channelRegistry, ChannelRegistry } from "./registry";
+
+describe("ChannelRegistry", () => {
+  it("returns capability metadata from listCapabilities", () => {
+    const registry = new ChannelRegistry();
+
+    registry.register({
+      id: "demo",
+      displayName: "Demo",
+      description: "Demo channel",
+      capabilities: {
+        transport: "webhook",
+        supportsInboundAttachments: false,
+        auth: "token",
+        productionReadiness: "beta",
+      },
+      create: () => ({
+        id: "demo",
+        type: "webhook",
+        start: async () => {},
+        stop: async () => {},
+        handleMessage: async () => {},
+        stream: async () => {},
+      }),
+    });
+
+    expect(registry.listCapabilities()).toEqual([
+      {
+        id: "demo",
+        displayName: "Demo",
+        description: "Demo channel",
+        capabilities: {
+          transport: "webhook",
+          supportsInboundAttachments: false,
+          auth: "token",
+          productionReadiness: "beta",
+        },
+      },
+    ]);
+  });
+
+  it("registers built-in channel capabilities on the shared registry", () => {
+    registerBuiltinChannels();
+
+    const web = channelRegistry.get("web");
+    const discord = channelRegistry.get("discord");
+
+    expect(web?.capabilities.transport).toBe("sse");
+    expect(web?.capabilities.supportsInboundAttachments).toBe(true);
+
+    expect(discord?.capabilities.transport).toBe("websocket");
+    expect(discord?.capabilities.controls).toContain("requireMention");
+  });
+});

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -1,5 +1,20 @@
 import type { Channel, ChannelRuntimeContext, ChannelConfig } from "./channel";
 
+export type ChannelTransportType = "webhook" | "websocket" | "sse";
+
+export interface ChannelCapabilityMetadata {
+  /** Channel transport behavior. */
+  transport: ChannelTransportType;
+  /** Whether the channel supports inbound attachments natively. */
+  supportsInboundAttachments: boolean;
+  /** Primary authentication/configuration strategy summary. */
+  auth: string;
+  /** Optional controls for mention/scope/allowlist behavior. */
+  controls?: string[];
+  /** Production readiness guidance. */
+  productionReadiness: "ready" | "beta";
+}
+
 export interface ChannelFactory<TConfig extends ChannelConfig> {
   /** Unique channel identifier (e.g., "discord") */
   id: string;
@@ -7,6 +22,8 @@ export interface ChannelFactory<TConfig extends ChannelConfig> {
   displayName: string;
   /** Short description for UI/tooling */
   description?: string;
+  /** Structured channel capability metadata for docs/tooling. */
+  capabilities: ChannelCapabilityMetadata;
   /** Create a channel instance from config */
   create(config: TConfig, context: ChannelRuntimeContext): Channel;
 }
@@ -40,6 +57,22 @@ export class ChannelRegistry {
    */
   list(): ChannelFactory<any>[] {
     return Array.from(this.factories.values());
+  }
+
+  /**
+   * List capability metadata for all registered channels.
+   */
+  listCapabilities(): Array<
+    Pick<ChannelFactory<any>, "id" | "displayName" | "description"> & {
+      capabilities: ChannelCapabilityMetadata;
+    }
+  > {
+    return this.list().map((factory) => ({
+      id: factory.id,
+      displayName: factory.displayName,
+      description: factory.description,
+      capabilities: factory.capabilities,
+    }));
   }
 }
 


### PR DESCRIPTION
### Motivation

- Ensure the channel capability matrix is a single source of truth derived from runtime code instead of hand-maintained docs.
- Provide structured capability metadata so tooling and the UI can introspect channel properties reliably.
- Add lightweight architecture guardrails and a generation workflow to keep docs and boundaries in sync with code.

### Description

- Introduced `ChannelCapabilityMetadata`, extended `ChannelFactory` with a `capabilities` field, and added `ChannelRegistry.listCapabilities()` in `src/channels/registry.ts` to expose typed capability metadata.
- Populated structured capability metadata for built-in channels in `src/channels/builtin.ts` (DingTalk, WeCom, Web, Discord, Feishu) and kept existing factory wiring intact.
- Added `scripts/generate-channel-capability-matrix.ts` and a `docs:channels` script in `package.json` to render `docs/reference/channel-capability-matrix.md` from registry metadata.
- Added a targeted test `src/channels/registry.test.ts` to validate capability introspection and a lightweight architecture validator `scripts/verify-architecture.ts` to catch forbidden cross-layer imports.

### Testing

- Ran `pnpm docs:channels`, which successfully generated `docs/reference/channel-capability-matrix.md` (output: `Wrote docs/reference/channel-capability-matrix.md`).
- Ran the targeted test with `pnpm exec vitest run src/channels/registry.test.ts`, which passed (2 tests passed).
- Ran `pnpm verify:architecture`, which completed successfully with `Architecture boundary check passed (360 files scanned).`.
- Ran `pnpm typecheck` (`tsc --noEmit`), which completed without type errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dde6fcaa0832e878ba99b8aecff68)