### PR TITLE
Update documentation terminology (Viber Node -> Viber, Viber -> Task)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ cp .env.example .env
 
 ### 3. Launch full stack
 ```bash
-# Starts Hub (6007), Viber runtime (connects to Hub), and Web UI (6006)
+# Starts Gateway (6007), Viber runtime (connects to Gateway), and Web UI (6006)
 pnpm dev
 ```
 - **Viber Board (Web UI)**: [http://localhost:6006](http://localhost:6006)
-- **Viber Hub**: [http://localhost:6007](http://localhost:6007)
+- **Viber Gateway**: [http://localhost:6007](http://localhost:6007)
 
 ---
 
@@ -90,10 +90,10 @@ viber chat
 ```
 
 ### 🌐 Viber Board (Web UI)
-A modern, visual interface to manage your vibers, monitor jobs, and chat in real-time. Accessible at `http://localhost:6006` when running `pnpm dev`.
+A modern, visual interface to manage your tasks, monitor jobs, and chat in real-time. Accessible at `http://localhost:6006` when running `pnpm dev`.
 
 ### 🏢 Enterprise Channels
-Deploy your vibers to where your team works. Support for **DingTalk** and **WeCom** is built-in.
+Deploy your tasks to where your team works. Support for **DingTalk** and **WeCom** is built-in.
 
 ```bash
 # Start the enterprise channel server
@@ -119,7 +119,7 @@ Location: `~/.openviber/vibers/default/`
 
 ## ✨ Key Features
 
-### 🤖 Viber Workforce (Jobs)
+### 🤖 Task Workforce (Jobs)
 Deploy autonomous workers via simple YAML cron jobs.
 ```yaml
 # examples/jobs/morning-standup.yaml
@@ -153,7 +153,7 @@ Maintain control with approval gates. Tasks can be configured to pause and ask f
 │                    Viber                        │
 │                                                 │
 │  ┌────────────────────────────────────────────┐  │
-│  │  dev-viber │ researcher-viber │ pm-viber   │  │
+│  │  dev-task  │ researcher-task  │ pm-task    │  │
 │  └────────────────────────────────────────────┘  │
 │        │                                        │
 │   ┌────┴─────────────────────┐                  │

--- a/docs/concepts/jobs.md
+++ b/docs/concepts/jobs.md
@@ -12,7 +12,7 @@ description: "Scheduled tasks that run automatically on a timer"
 A job is a YAML file that defines:
 
 - **When** to run (cron schedule)
-- **What** to do (a prompt for the agent)
+- **What** to do (a prompt for the task)
 - **How** to do it (model, skills, tools configuration)
 
 Jobs are the bridge between "set it up once" and "it runs forever." Combined with skills, they enable powerful autonomous workflows like health monitoring, daily summaries, and automated issue fixing.
@@ -24,17 +24,17 @@ Jobs are the bridge between "set it up once" and "it runs forever." Combined wit
 1. **Definition** — You create a YAML file in the jobs directory (or use the `create_scheduled_job` tool via chat)
 2. **Loading** — The `JobScheduler` reads all `.yaml`/`.yml` files from the jobs directory at startup
 3. **Scheduling** — Each job's cron expression is registered with the [Croner](https://github.com/hexagon/croner) scheduler
-4. **Execution** — When the cron fires, the scheduler creates an `Agent` with the job's configuration and runs the prompt
+4. **Execution** — When the cron fires, the scheduler creates a `Task` with the job's configuration and runs the prompt
 5. **Logging** — Results (tool outputs, LLM responses) are logged to the console; healthy/routine results are suppressed for noise reduction
 
 ### Execution Model
 
 When a job fires, the scheduler:
 
-1. Creates a fresh `Agent` instance with the job's `model`, `skills`, and `tools`
+1. Creates a fresh `Task` instance with the job's `model`, `skills`, and `tools`
 2. Sends the job's `prompt` as a user message
-3. The agent reasons, calls tools (including skill-provided tools), and generates a response
-4. Tool results and the agent's text response are logged
+3. The task reasons, calls tools (including skill-provided tools), and generates a response
+4. Tool results and the task's text response are logged
 5. Routine "healthy" results (e.g., `status: HEALTHY` from antigravity) are automatically suppressed from logs
 
 If no `model` is specified, the job is skipped with a warning — a model is required for execution.
@@ -70,8 +70,8 @@ prompt: |
 | `model` | Yes* | — | Model to use (e.g., `deepseek/deepseek-chat`) |
 | `skills` | No | `[]` | Skills to enable for this job |
 | `tools` | No | `[]` | Additional tools to enable |
-| `prompt` | Yes | — | The task/instruction for the agent |
-| `nodeId` | No | — | Target a specific viber node (for gateway/Board-pushed jobs) |
+| `prompt` | Yes | — | The instruction for the task |
+| `nodeId` | No | — | Target a specific Viber (for gateway/Board-pushed jobs) |
 
 *Jobs without a `model` field are skipped at execution time.
 
@@ -121,9 +121,9 @@ Jobs use standard cron syntax. Both 5-field (minute-level) and 6-field (second-l
 
 Jobs can be stored in two places:
 
-### Per-Viber Jobs
+### Per-Task Jobs
 
-Each viber has its own job directory:
+Each task has its own job directory:
 
 ```
 ~/.openviber/vibers/
@@ -136,11 +136,11 @@ Each viber has its own job directory:
         └── weekly-report.yaml
 ```
 
-Per-viber jobs are loaded when the viber starts. They inherit the viber's context and run in its scope.
+Per-task jobs are loaded when the task starts. They inherit the task's context and run in its scope.
 
 ### Global Jobs
 
-Shared jobs that aren't tied to a specific viber:
+Shared jobs that aren't tied to a specific task:
 
 ```
 ~/.openviber/jobs/
@@ -197,7 +197,7 @@ The tool accepts natural language schedules and converts them to cron:
 
 ### Method 3: Gateway (Remote)
 
-Jobs can be pushed from the OpenViber Board to a connected node via the `job:create` WebSocket message. The gateway sends the job configuration and the node writes it to disk, then triggers a scheduler reload.
+Jobs can be pushed from the OpenViber Board to a connected Viber via the `job:create` WebSocket message. The gateway sends the job configuration and the Viber writes it to disk, then triggers a scheduler reload.
 
 ## Schedule Tools
 
@@ -217,13 +217,13 @@ These tools operate on the global jobs directory (`~/.openviber/jobs/`).
 You:   "Create a job called 'morning-brief' that runs at 8am daily
         and summarizes my GitHub notifications"
 
-Viber: Created job "morning-brief" — will run at schedule: 0 8 * * *
+Task:  Created job "morning-brief" — will run at schedule: 0 8 * * *
        Job saved to ~/.openviber/jobs/morning-brief.yaml
        Restart OpenViber to load the new job.
 
 You:   "List my scheduled jobs"
 
-Viber: You have 2 scheduled jobs:
+Task:  You have 2 scheduled jobs:
        1. morning-brief — 0 8 * * * — "Summarize my GitHub notifications..."
        2. health-check — */3 * * * * * — "Check Antigravity IDE health..."
 ```
@@ -321,7 +321,7 @@ Hot-reloading of job files is planned but not yet implemented.
 
 ## Next Steps
 
-- [Skills](/docs/concepts/skills) — Domain knowledge for job agents
+- [Skills](/docs/concepts/skills) — Domain knowledge for job tasks
 - [Tools](/docs/concepts/tools) — Actions available to jobs
 - [Viber](/docs/concepts/viber) — Viber configuration and working modes
 - [Config Schema](/docs/reference/config-schema) — Full YAML schema reference

--- a/docs/concepts/viber.md
+++ b/docs/concepts/viber.md
@@ -1,34 +1,46 @@
 # Viber
 
-> **You Imagine It. Vibers Build It.**
+> **You Imagine It. Tasks Build It.**
 
-A **viber** is a role-scoped AI worker that runs on your machine. It has its own persona, goals, tools, and guardrails — think of it as a specialized teammate who works from your computer.
+A **Viber** is your machine running the OpenViber runtime. It acts as a host for **Tasks** — role-scoped AI workers that execute your commands.
 
 ## How It Works
 
 ```mermaid
 graph TB
-    subgraph node["Viber(your machine)"]
+    subgraph node["Viber (your machine)"]
         subgraph openviber["OpenViber runtime"]
-            v1["dev-viber"]
-            v2["researcher-viber"]
-            v3["pm-viber"]
+            v1["dev-task"]
+            v2["researcher-task"]
+            v3["pm-task"]
         end
     end
 ```
 
-Your machine becomes a **Viber Node** — a runtime that hosts one or more vibers. Each viber has a distinct role. You talk to them naturally:
+Your machine becomes a **Viber** — a runtime that hosts one or more tasks. Each task has a distinct role. You talk to them naturally:
 
 ```
 You:   "Build a landing page for our new product, dark theme"
-Viber: I'll create a landing page. Here's my plan:
+Task:  I'll create a landing page. Here's my plan:
        1. Scaffold Next.js project
        2. Design hero + feature sections
        3. Deploy to Vercel
        Should I proceed?
 You:   "Go ahead"
-Viber: On it. You can watch in the terminal panel...
+Task:  On it. You can watch in the terminal panel...
 ```
+
+## Tasks
+
+A **Task** is the unit of work in OpenViber. It combines:
+
+| Element                 | What It Gives You                                                            |
+| ----------------------- | ---------------------------------------------------------------------------- |
+| **Persona & Goals**     | Role focus — not a generic assistant, but a specialist with clear objectives |
+| **Machine Runtime**     | Real execution — terminal, browser, files, apps on your machine              |
+| **Identity & Accounts** | Agency — acts on your behalf across GitHub, email, cloud services            |
+
+This is what separates tasks from chatbots: they don't just answer questions, they **do the work**.
 
 ## Intent-Driven Creation (Viber Board)
 
@@ -37,7 +49,7 @@ In the web UI, the **New Task** flow is intent-first and environment-aware:
 1. Pick an intent template (for example: _Build a Feature_, _Code Review_, _Railway Deploy Failures_)
 2. OpenViber pre-fills the task goal from the template
 3. OpenViber infers required skills from the intent
-4. OpenViber compares required skills against the selected node's currently available skills
+4. OpenViber compares required skills against the selected Viber's currently available skills
 5. If a required skill is missing, the UI opens a guided prerequisite flow before launch
 6. Once required skills are ready, the task auto-launches with the selected intent body
 
@@ -53,14 +65,14 @@ This gives good defaults for built-in templates while still letting you create p
 
 ### Guided Setup Before Launch
 
-When a selected node is active but a required skill is not ready on that node, OpenViber starts a proactive setup flow:
+When a selected Viber is active but a required skill is not ready on that machine, OpenViber starts a proactive setup flow:
 
-- checks node availability
+- checks Viber availability
 - runs skill provisioning for supported skills
 - handles auth guidance when the skill needs external login
 - retries launch automatically when prerequisites become available
 
-If the node is offline, OpenViber asks you to bring it online before launching the task.
+If the Viber is offline, OpenViber asks you to bring it online before launching the task.
 
 ### Where to Manage Intents
 
@@ -70,61 +82,49 @@ You can manage built-in and custom intent templates in **Settings → Intents**:
 - replicate built-in templates into editable user templates
 - keep intent instructions aligned with your team workflows
 
-## What Makes a Viber
-
-A viber combines three elements that no chat-only AI has:
-
-| Element                 | What It Gives You                                                            |
-| ----------------------- | ---------------------------------------------------------------------------- |
-| **Persona & Goals**     | Role focus — not a generic assistant, but a specialist with clear objectives |
-| **Machine Runtime**     | Real execution — terminal, browser, files, apps on your machine              |
-| **Identity & Accounts** | Agency — acts on your behalf across GitHub, email, cloud services            |
-
-This is what separates vibers from chatbots: they don't just answer questions, they **do the work**.
-
 ## Working Modes
 
 | Mode               | When to Use                                                    |
 | ------------------ | -------------------------------------------------------------- |
-| **Always Ask**     | Building trust — viber asks before each action                 |
-| **Viber Decides**  | Daily work — viber acts within policy, escalates risky actions |
+| **Always Ask**     | Building trust — task asks before each action                  |
+| **Task Decides**   | Daily work — task acts within policy, escalates risky actions (also known as "Viber Decides") |
 | **Always Execute** | Overnight runs — maximum autonomy, intervene by exception      |
 
-Start with "Always Ask" and graduate to "Viber Decides" as you build confidence.
+Start with "Always Ask" and graduate to "Task Decides" as you build confidence.
 
 ## You Stay in Control
 
-Your viber works autonomously but you always have oversight:
+Your tasks work autonomously but you always have oversight:
 
 - **Observe** — Watch terminal output in real time via tmux streaming
 - **Intervene** — Pause, redirect, or stop at any point through chat
 - **Approve** — Sensitive actions require explicit permission
 - **Audit** — Every action is logged; budget limits prevent runaway costs
 
-## Viber Node
+## The Viber Runtime
 
-A **Viber Node** is a single machine running the OpenViber runtime. It provides:
+A **Viber** is a single machine running the OpenViber runtime. It provides:
 
-- **Scheduler** — Runs viber tasks on cron schedules (daily research, weekly reports)
-- **Credentials** — Shared account access for all vibers on the node
-- **Config** — Identity and viber settings at `~/.openviber/` (lightweight, portable)
+- **Scheduler** — Runs tasks on cron schedules (daily research, weekly reports)
+- **Credentials** — Shared account access for all tasks on the Viber
+- **Config** — Identity and settings at `~/.openviber/` (lightweight, portable)
 - **Spaces** — Working data at `~/openviber_spaces/` (repos, research, outputs)
 
-### Adding a Node
+### Adding a Viber
 
-From the OpenViber Board, click **Add Node** to generate a one-liner:
+From the OpenViber Board, click **Add Viber** to generate a one-liner:
 
 ```bash
 npx openviber connect --token eyJub2RlIjoiYTFiMmMz...
 ```
 
-This bootstraps the node, creates `~/.openviber/`, and connects to the Board — no inbound ports needed.
+This bootstraps the Viber, creates `~/.openviber/`, and connects to the Board — no inbound ports needed.
 
-Multiple vibers coordinate through **external systems** (GitHub issues, email) rather than talking to each other directly. This keeps everything simple and stateless.
+Multiple tasks coordinate through **external systems** (GitHub issues, email) rather than talking to each other directly. This keeps everything simple and stateless.
 
 ## Next Steps
 
-- [Tools](/docs/concepts/tools) — What vibers can do
+- [Tools](/docs/concepts/tools) — What tasks can do
 - [Skills](/docs/concepts/skills) — Domain knowledge bundles with specialized tools
-- [Jobs](/docs/concepts/jobs) — Schedule recurring tasks for your vibers
-- [Memory](/docs/concepts/memory) — How vibers remember context
+- [Jobs](/docs/concepts/jobs) — Schedule recurring tasks
+- [Memory](/docs/concepts/memory) — How tasks remember context

--- a/docs/design/viber.md
+++ b/docs/design/viber.md
@@ -1,11 +1,11 @@
 ---
 title: "Viber Design"
-description: "Top-down architecture: what a viber is, how viber nodes work, and how vibers operate"
+description: "Top-down architecture: what a Viber is, how it works, and how tasks operate"
 ---
 
 # Viber Design
 
-OpenViber is a workspace-first platform where each **viber** is a role-scoped AI worker running on a machine you own.
+OpenViber is a workspace-first platform where each **task** is a role-scoped AI worker running on a machine you own (the **Viber**).
 
 ---
 
@@ -13,16 +13,16 @@ OpenViber is a workspace-first platform where each **viber** is a role-scoped AI
 
 | Term | Definition |
 |------|-----------|
-| **Viber** | A role-scoped worker with its own persona, goals, tools, budget, and guardrails. |
-| **Viber Node** | A machine running the OpenViber runtime that hosts one or more vibers. A deployment target, not a UI level. |
-| **OpenViber Board** | The web cockpit operators use to observe, chat with, and control vibers. |
-| **Space** | A working directory (repo, research folder, output directory) that vibers operate in. |
+| **Task** | A role-scoped worker with its own persona, goals, tools, budget, and guardrails. |
+| **Viber** | A machine running the OpenViber runtime that hosts one or more tasks. A deployment target, not a UI level. |
+| **OpenViber Board** | The web cockpit operators use to observe, chat with, and control tasks. |
+| **Space** | A working directory (repo, research folder, output directory) that tasks operate in. |
 
-A viber combines three elements:
+A task combines three elements:
 
 ```mermaid
 flowchart LR
-    subgraph Viber["One Viber"]
+    subgraph Task["One Task"]
       Agent["ViberAgent"]
       Machine["Machine runtime<br/>(terminal, browser, files, apps)"]
       Identity["Identity + accounts<br/>(GitHub, Google, cloud services)"]
@@ -34,7 +34,7 @@ flowchart LR
     Agent --> Budget
 ```
 
-The project is **OpenViber**; each deployed worker is a **viber**.
+The project is **OpenViber**; the machine is a **Viber**; each deployed worker is a **task**.
 
 ---
 
@@ -51,11 +51,11 @@ flowchart LR
     subgraph Gateway["Gateway (optional relay)"]
       WS["WS route"]
     end
-    subgraph Node["Viber Node"]
+    subgraph Viber["Viber (Machine)"]
       Scheduler["Scheduler + dispatcher"]
-      V1["dev-viber"]
-      V2["researcher-viber"]
-      V3["pm-viber"]
+      V1["dev-task"]
+      V2["researcher-task"]
+      V3["pm-task"]
     end
     subgraph Config["~/.openviber/ (config)"]
       Cfg["config.yaml / user.md"]
@@ -81,8 +81,8 @@ flowchart LR
 ```
 
 Key properties:
-- **One node, many vibers.** A single Viber Node can host multiple vibers with distinct roles.
-- **Process-stateless node.** The node holds no in-memory state between requests; durable context lives on disk.
+- **One Viber, many tasks.** A single Viber can host multiple tasks with distinct roles.
+- **Process-stateless Viber.** The Viber holds no in-memory state between requests; durable context lives on disk.
 - **Config ≠ working data.** `~/.openviber/` holds config and identity (small, portable). `~/openviber_spaces/` holds repos, research, and outputs (large, git-managed).
 
 ---
@@ -95,16 +95,16 @@ OpenViber separates **config** from **working data** across two locations:
 
 ```
 ~/.openviber/
-├── config.yaml               # Node: daemon, providers, channels, security
-├── user.md                    # Shared: who you are (same for all vibers)
-├── skills/                    # Node: shared skill bundles
-├── mcp/                       # Node: MCP server configs
-└── vibers/
-    ├── dev.yaml               # Viber config: model, tools, skills, mode, budget
+├── config.yaml               # Viber: daemon, providers, channels, security
+├── user.md                   # Shared: who you are (same for all tasks)
+├── skills/                   # Viber: shared skill bundles
+├── mcp/                      # Viber: MCP server configs
+└── vibers/                   # Task configurations
+    ├── dev.yaml              # Task config: model, tools, skills, mode, budget
     ├── dev/
-    │   ├── soul.md            # Persona for this viber
-    │   ├── memory.md          # Long-term memory
-    │   └── sessions/          # Conversation logs (*.jsonl)
+    │   ├── soul.md           # Persona for this task
+    │   ├── memory.md         # Long-term memory
+    │   └── sessions/         # Conversation logs (*.jsonl)
     ├── researcher.yaml
     └── researcher/
         ├── soul.md
@@ -116,21 +116,21 @@ OpenViber separates **config** from **working data** across two locations:
 
 ```
 ~/openviber_spaces/
-├── my-webapp/                 # Cloned repo (dev-viber works here)
+├── my-webapp/                 # Cloned repo (dev-task works here)
 ├── data-pipeline/             # Another repo
-├── market-research/           # Research viber workspace
-└── weekly-reports/            # Reporting viber output
+├── market-research/           # Research task workspace
+└── weekly-reports/            # Reporting task output
 ```
 
 ### Scoping rules
 
 | Scope | What | Why |
 |-------|------|-----|
-| **Node** | `config.yaml`, `user.md`, `skills/`, `mcp/` | Shared across all vibers on this machine |
-| **Viber** | `vibers/{id}.yaml`, `soul.md`, `memory.md`, `sessions/` | Each viber has its own role, memory, and history |
-| **Space** | `~/openviber_spaces/*` | Multiple vibers can work on the same space |
+| **Viber** | `config.yaml`, `user.md`, `skills/`, `mcp/` | Shared across all tasks on this machine |
+| **Task** | `vibers/{id}.yaml`, `soul.md`, `memory.md`, `sessions/` | Each task has its own role, memory, and history |
+| **Space** | `~/openviber_spaces/*` | Multiple tasks can work on the same space |
 
-Vibers declare which spaces they work on:
+Tasks declare which spaces they work on:
 
 ```yaml
 # ~/.openviber/vibers/dev.yaml
@@ -139,7 +139,7 @@ spaces:
   - ~/code/legacy-api           # can point anywhere
 ```
 
-The node reads and writes config but remains process-stateless — restart freely without losing context.
+The Viber reads and writes config but remains process-stateless — restart freely without losing context.
 
 ---
 
@@ -149,8 +149,8 @@ OpenViber exposes familiar autonomy profiles:
 
 | Mode | Description |
 |------|-------------|
-| **Always Ask** | Viber asks before each execution action. |
-| **Viber Decides** | Active execution within policy-based approval boundaries. |
+| **Always Ask** | Task asks before each execution action. |
+| **Task Decides** | Active execution within policy-based approval boundaries. (also known as "Viber Decides") |
 | **Always Execute** | High autonomy; intervene by exception. |
 
 All modes share one loop: **observe → plan → execute → verify → report → request feedback → continue**.
@@ -162,7 +162,7 @@ All modes share one loop: **observe → plan → execute → verify → report �
 The operator always has oversight:
 
 - **Chat** is the default intervention path — pause, resume, reprioritize, re-scope.
-- **Terminal observability** via tmux streaming — watch what the viber does in real time.
+- **Terminal observability** via tmux streaming — watch what the task does in real time.
 - **Approval gates** for sensitive actions (file writes, deploys, sends).
 - **Budget limits** prevent runaway costs.
 - **Audit trail** — every action is logged to session JSONL.
@@ -180,24 +180,24 @@ Acceptance must come from human-observable evidence, not self-grading:
 
 ---
 
-## 7. Multi-Viber Coordination
+## 7. Multi-Task Coordination
 
-When multiple vibers run on one node, they coordinate through **external systems**, not direct messaging:
+When multiple tasks run on one Viber, they coordinate through **external systems**, not direct messaging:
 
 ```
-researcher-viber → writes report → GitHub issue (state:needs-triage)
-pm-viber         → triages issue → labels state:ready-for-dev
-dev-viber        → implements    → opens PR (Fixes #...)
-comms-viber      → announces     → GitHub release + email
+researcher-task  → writes report → GitHub issue (state:needs-triage)
+pm-task          → triages issue → labels state:ready-for-dev
+dev-task         → implements    → opens PR (Fixes #...)
+comms-task       → announces     → GitHub release + email
 ```
 
-This keeps each viber **independent and stateless** — no inter-viber protocol, no orchestration complexity. The handoff state machine lives in GitHub labels, not in OpenViber.
+This keeps each task **independent and stateless** — no inter-task protocol, no orchestration complexity. The handoff state machine lives in GitHub labels, not in OpenViber.
 
 ---
 
-## 8. Node Onboarding
+## 8. Viber Onboarding
 
-Inspired by Cloudflare Zero Trust tunnels — the Board generates a one-liner that bootstraps and connects a new node.
+Inspired by Cloudflare Zero Trust tunnels — the Board generates a one-liner that bootstraps and connects a new Viber.
 
 ### Flow
 
@@ -207,13 +207,13 @@ sequenceDiagram
     participant U as User
     participant N as Target Machine
 
-    U->>B: Click "Add Node"
-    B->>B: Generate node ID + one-time token
+    U->>B: Click "Add Viber"
+    B->>B: Generate Viber ID + one-time token
     B->>U: Show command in dialog
     U->>N: Paste & run command
     N->>N: npx openviber connect --token <TOKEN>
     N->>B: WebSocket handshake (token auth)
-    B->>N: Node registered ✓
+    B->>N: Viber registered ✓
 ```
 
 ### The Command
@@ -224,29 +224,29 @@ npx openviber connect --token eyJub2RlIjoiYTFiMmMz...
 
 This single command:
 1. Installs/updates OpenViber (via `npx`)
-2. Creates `~/.openviber/` with the node config
-3. Registers the node with the Board using the embedded token
-4. Starts the node runtime and connects via WebSocket
+2. Creates `~/.openviber/` with the Viber config
+3. Registers the Viber with the Board using the embedded token
+4. Starts the Viber runtime and connects via WebSocket
 
 ### Security Properties
 
 | Property | How |
 |----------|-----|
 | **One-time token** | Expires after first use or after TTL |
-| **No inbound ports** | Node connects outbound to the Board |
+| **No inbound ports** | Viber connects outbound to the Board |
 | **Device binding** | After initial connect, device ID is pinned |
-| **Revocable** | Board can revoke node access at any time |
+| **Revocable** | Board can revoke Viber access at any time |
 
 ---
 
 ## 9. Gateway (Central Coordinator)
 
-After onboarding, the node communicates with the Viber Board (web app) via a WebSocket control plane.
+After onboarding, the Viber communicates with the Viber Board (web app) via a WebSocket control plane.
 In this repo, that control plane is implemented by the **Gateway** (`viber gateway`). This is distinct
-from the **Channels** server (`viber channels`, enterprise channel webhooks) and from the **node runtime**
+from the **Channels** server (`viber channels`, enterprise channel webhooks) and from the **Viber runtime**
 (often called the daemon).
 
-- **Single gateway per host** — one node is the authority for channel connections and viber runs on that machine.
+- **Single gateway per host** — one Viber is the authority for channel connections and tasks run on that machine.
 - **WebSocket control plane** — all clients (Board, CLI, automation) connect over a typed WS protocol, declaring **role + scopes** at handshake.
 - **Idempotency keys** for side-effecting requests to allow safe retries.
 - **Events are push-only** — clients must refresh state on gaps; events are not replayed.
@@ -257,9 +257,9 @@ from the **Channels** server (`viber channels`, enterprise channel webhooks) and
 ## 10. Design Principles
 
 1. **Config ≠ working data** — `~/.openviber/` for config, `~/openviber_spaces/` for work.
-2. **Process-stateless** — the node can restart at any time without data loss.
-3. **Role-scoped vibers** — each viber has a clear role, not a generic all-purpose agent.
-4. **External coordination** — vibers coordinate through tools (GitHub, email), not inter-viber messaging.
+2. **Process-stateless** — the Viber can restart at any time without data loss.
+3. **Role-scoped tasks** — each task has a clear role, not a generic all-purpose agent.
+4. **External coordination** — tasks coordinate through tools (GitHub, email), not inter-task messaging.
 5. **Human oversight** — operators can always observe, intervene, and approve.
 6. **Evidence-based verification** — no unverifiable self-grading.
 7. **Token-based onboarding** — zero inbound ports, one command to connect.

--- a/docs/getting-started/onboarding.md
+++ b/docs/getting-started/onboarding.md
@@ -1,6 +1,6 @@
 # Getting Started with OpenViber
 
-OpenViber is an AI agent that runs on your machine. There are two ways to set it up:
+OpenViber is a platform for running AI tasks on your machine. There are two ways to set it up:
 
 - **Standalone mode**: local CLI/daemon only, no web control plane required.
 - **Connected mode**: your local **Viber** is registered to a **Gateway** and controlled from the **Viber Board** (web UI).
@@ -9,26 +9,26 @@ Use this guide if you want explicit onboarding steps for both modes and a clear 
 
 ## Option A: Connect to OpenViber Web (Recommended)
 
-This connects your local viber to the web dashboard where you can manage config,
-send tasks, and monitor your viber remotely.
+This connects your local Viber to the web dashboard where you can manage config,
+send tasks, and monitor your Viber remotely.
 
 ### Step 1: Create a Viber on the Web
 
 1. Log in to [OpenViber Web](http://localhost:6006) (or your deployed URL)
 2. Go to **Vibers** → Click **"Add Viber"**
-3. Give your viber a name
+3. Give your Viber a name
 4. Copy the generated command
 
 ### Optional: Create a task from an intent
 
-After the viber is online, open **Tasks → New Task** and choose an intent template (for example, _Build a Feature_ or _Code Review_).
+After the Viber is online, open **Tasks → New Task** and choose an intent template (for example, _Build a Feature_ or _Code Review_).
 
 The task launch flow is:
 
-1. Select an active viber
+1. Select an active Viber
 2. Select an intent template (or paste your own goal)
 3. OpenViber infers required skills from template metadata, `skills:` blocks, and keywords
-4. If the selected viber is missing required skills, OpenViber starts guided provisioning before launch
+4. If the selected Viber is missing required skills, OpenViber starts guided provisioning before launch
 5. After prerequisites are ready, the task launches automatically with the selected intent body
 
 Supported proactive skill provisioning currently covers:
@@ -74,14 +74,14 @@ Get an API key at: [openrouter.ai/keys](https://openrouter.ai/keys)
 npx openviber start
 ```
 
-That's it! Your viber will automatically connect to OpenViber Web.
+That's it! Your Viber will automatically connect to OpenViber Web.
 **No extra flags needed** — it reads your saved config.
 
 ---
 
 ## Option B: Standalone Setup (Local Only)
 
-If you just want to run a viber locally without the web dashboard:
+If you just want to run a Viber locally without the web dashboard:
 
 ```bash
 npx openviber onboard
@@ -129,15 +129,15 @@ Viber Gateway (:6007)
 Your local OpenViber Daemon (Viber)
 ```
 
-Connected mode uses an onboarding token to bind your local viber to the gateway project/workspace so the board can dispatch tasks and observe status.
+Connected mode uses an onboarding token to bind your local Viber to the gateway project/workspace so the board can dispatch tasks and observe status.
 
 ### Component Responsibilities
 
 | Component | Role during onboarding | Role after onboarding |
 | --- | --- | --- |
 | Viber (local daemon) | Creates local runtime state and (in connected mode) exchanges token for persistent connection config. | Executes tasks, streams status/events, manages local memories/skills/tools. |
-| Gateway (`:6007`) | Validates onboarding token and associates viber identity to backend records. | Routes commands/events between viber and board. |
-| Viber Board (`:6006`) | Creates viber records and issues short-lived onboard tokens. | Operator UI for launching, monitoring, and configuring vibers. |
+| Gateway (`:6007`) | Validates onboarding token and associates Viber identity to backend records. | Routes commands/events between Viber and board. |
+| Viber Board (`:6006`) | Creates Viber records and issues short-lived onboard tokens. | Operator UI for launching, monitoring, and configuring Vibers. |
 
 ---
 
@@ -152,21 +152,21 @@ Connected mode uses an onboarding token to bind your local viber to the gateway 
 
 ### Connected checklist (Gateway + Board)
 
-1. Open Viber Board and create a viber to obtain a token.
+1. Open Viber Board and create a Viber to obtain a token.
 2. On the target machine, run `npx openviber onboard --token <token>` within 15 minutes.
 3. Start the daemon (`npx openviber start`).
-4. Verify the viber appears active/selectable in **Vibers** and **New Task** flows.
+4. Verify the Viber appears active/selectable in **Vibers** and **New Task** flows.
 5. Launch a test task from the board and confirm round-trip events.
 
 ---
 
 ## Current Gaps to Watch While Wiring
 
-When integrating viber + gateway + board, these are common missing pieces to identify early:
+When integrating Viber + Gateway + Board, these are common missing pieces to identify early:
 
 - **Connection diagnostics are still mostly manual**: users often fall back to `status`, logs, and page refreshes to understand handshake failures.
 - **Token lifecycle UX can be improved**: expired/invalid token feedback is functional but could be more guided across CLI and board.
-- **Post-onboarding verification is implicit**: there is no single built-in `onboarding doctor` flow that checks key, connectivity, and viber readiness end-to-end.
+- **Post-onboarding verification is implicit**: there is no single built-in `onboarding doctor` flow that checks key, connectivity, and Viber readiness end-to-end.
 - **Mode visibility could be clearer**: users may not immediately know whether they are running purely standalone or currently linked to a gateway workspace.
 
 If you are setting up team onboarding, treat the checklist above as a baseline and document your environment-specific validation steps (auth provider, deployment URL, proxy, and firewall rules).
@@ -181,11 +181,11 @@ After onboarding, your `~/.openviber/` directory looks like:
 ~/.openviber/
 ├── config.yaml          # Connection config (auto-generated)
 ├── viber-id             # Unique machine identifier
-├── user.md              # Your context (shared across vibers)
-├── vibers/
-│   ├── default.yaml     # Default viber configuration
+├── user.md              # Your context (shared across tasks)
+├── vibers/              # Task configurations
+│   ├── default.yaml     # Default task configuration
 │   └── default/
-│       ├── soul.md      # Viber personality
+│       ├── soul.md      # Task personality
 │       └── memory.md    # Long-term notes
 └── skills/              # Custom skills
 ```
@@ -198,22 +198,22 @@ After onboarding, your `~/.openviber/` directory looks like:
 | ----------------------------------- | ------------------------ |
 | `npx openviber onboard`             | Set up standalone mode   |
 | `npx openviber onboard --token <t>` | Connect to OpenViber Web |
-| `npx openviber start`               | Start the viber daemon   |
+| `npx openviber start`               | Start the Viber daemon   |
 | `npx openviber run "<task>"`        | Run a one-off task       |
 | `npx openviber chat`                | Interactive chat mode    |
-| `npx openviber status`              | Check viber status       |
+| `npx openviber status`              | Check Viber status       |
 
 ---
 
 ## Troubleshooting
 
-**Token expired?** Create a new viber on the web and run `npx openviber onboard --token` again.
+**Token expired?** Create a new Viber on the web and run `npx openviber onboard --token` again.
 
 **Can't connect?** Make sure OpenViber Web is running. By default: `http://localhost:6006`
 
-**Intent launch says a skill is missing?** Keep the target viber selected and use the guided setup dialog to provision prerequisites, then retry launch.
+**Intent launch says a skill is missing?** Keep the target Viber selected and use the guided setup dialog to provision prerequisites, then retry launch.
 
-**Viber not selectable in New Task?** Only active (connected) vibers can receive launches. Start your local daemon with `npx openviber start` and refresh the page.
+**Viber not selectable in New Task?** Only active (connected) Vibers can receive launches. Start your local daemon with `npx openviber start` and refresh the page.
 
 **Need to switch modes?** You can always re-run `npx openviber onboard --token <token>` to switch
 from standalone to connected mode.

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -5,7 +5,7 @@ description: "Get OpenViber running in minutes"
 
 # Quick Start
 
-Get your first viber up and running in minutes.
+Get your first task up and running in minutes.
 
 ## 1. Fastest Way (npx)
 
@@ -19,14 +19,14 @@ export OPENROUTER_API_KEY="your_api_key_here"
 npx openviber start
 ```
 
-This starts the **Viber Node** on your machine. You can now use the CLI to interact with it.
+This starts the **Viber** on your machine. You can now use the CLI to interact with it.
 
 ## 2. Interactive Chat
 
 OpenViber integrates with your terminal. Open a new terminal window:
 
 ```bash
-# Chat with your running viber
+# Chat with your running task
 npx openviber chat
 ```
 
@@ -52,7 +52,7 @@ cp .env.example .env
 
 ### Launch
 ```bash
-# Start the full stack (Gateway, Viber Node, and Web UI)
+# Start the full stack (Gateway, Viber, and Web UI)
 pnpm dev
 ```
 
@@ -61,7 +61,7 @@ Open [http://localhost:6006](http://localhost:6006) to see the Viber Board.
 ## Next Steps
 
 - [Introduction](/docs/introduction) — What OpenViber is and how it works
-- [Viber](/docs/concepts/viber) — Configure viber behavior
+- [Viber](/docs/concepts/viber) — Configure task behavior on your machine
 - [Tools](/docs/concepts/tools) — Available actions
 - [Skills](/docs/concepts/skills) — Add domain knowledge
 - [Jobs](/docs/concepts/jobs) — Set up scheduled tasks

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,13 +1,13 @@
 ---
 title: "Introduction"
-description: "You Imagine It. Vibers Build It."
+description: "You Imagine It. Tasks Build It."
 ---
 
 # Introduction
 
-**You Imagine It. Vibers Build It.**
+**You Imagine It. Tasks Build It.**
 
-**OpenViber** is an open-source platform that turns your machine into a **Viber Node** — a runtime that hosts role-scoped AI workers. You describe what you want, and vibers handle the work autonomously. Runs locally with full privacy, connects to your channels, and works while you sleep.
+**OpenViber** is an open-source platform that turns your machine into a **Viber** — a runtime that hosts role-scoped AI workers called **tasks**. You describe what you want, and tasks handle the work autonomously. Runs locally with full privacy, connects to your channels, and works while you sleep.
 
 The CLI is available as both `openviber` and the shorter alias `viber` (when installed).
 
@@ -26,10 +26,10 @@ OpenViber handles tasks that require multiple steps, file operations, web browsi
 
 ### 1. Viber Board (Web UI)
 
-Open the browser-based interface to chat with your viber:
+Open the browser-based interface to chat with your task:
 
 ```bash
-# Start the full stack (Gateway, Viber runtime, and Web UI)
+# Start the full stack (Gateway, Viber, and Web UI)
 pnpm dev
 # Open http://localhost:6006
 ```
@@ -39,7 +39,7 @@ pnpm dev
 Run one-off tasks or interact via terminal:
 
 ```bash
-# Start a task (local runtime)
+# Start a task (on your local Viber)
 openviber run "Create a README for this project"
 
 # Interactive terminal chat (tmux-friendly)
@@ -62,10 +62,10 @@ openviber channels
 | Concept | What It Is |
 |---------|------------|
 | **Viber** | Your machine running the OpenViber daemon — manages tasks, jobs, and skills |
-| **Task** | A chat session / unit of work running on a viber |
-| **Tools** | Actions vibers can take (file, search, web, browser, desktop, schedule, notify) |
+| **Task** | A chat session / unit of work running on a Viber |
+| **Tools** | Actions tasks can take (file, search, web, browser, desktop, schedule, notify) |
 | **Skills** | Domain knowledge bundles (`SKILL.md` + optional tools) — antigravity, cursor-agent, codex-cli, github, terminal |
-| **Jobs** | Cron-scheduled tasks that run agents autonomously on a timer |
+| **Jobs** | Cron-scheduled tasks that run tasks autonomously on a timer |
 
 ## Working Modes
 
@@ -73,8 +73,8 @@ OpenViber supports three levels of autonomy:
 
 | Mode | Behavior |
 |------|----------|
-| **Always Ask** | Viber asks before each action — you approve everything |
-| **Viber Decides** | Viber acts within policy, escalates risky actions |
+| **Always Ask** | Task asks before each action — you approve everything |
+| **Task Decides** | Task acts within policy, escalates risky actions (also known as "Viber Decides") |
 | **Always Execute** | Maximum autonomy, intervene by exception |
 
 Start with "Always Ask" and gradually increase autonomy as you build trust.

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -28,7 +28,7 @@ A storage backend implementation. OpenViber supports:
 
 ### Context
 
-The accumulated information that vibers use to understand and respond to requests. Context includes:
+The accumulated information that tasks use to understand and respond to requests. Context includes:
 
 - Conversation history
 - Artifact contents
@@ -37,21 +37,21 @@ The accumulated information that vibers use to understand and respond to request
 
 ### Conversation History
 
-The complete record of messages between users and vibers within a Space. History persists across sessions, enabling vibers to maintain continuity.
+The complete record of messages between users and tasks within a Space. History persists across sessions, enabling tasks to maintain continuity.
 
 ## D
 
-### Daemon (Node Runtime)
+### Daemon (Viber Runtime)
 
-The local process running on a Viber Node that executes tasks and connects outbound to the
-Gateway. In docs, "daemon" and "node runtime" are used interchangeably.
+The local process running on a Viber that executes tasks and connects outbound to the
+Gateway. In docs, "daemon" and "Viber runtime" are used interchangeably.
 
 ## G
 
 ### Gateway
 
-The central coordinator that routes messages between node runtimes (daemons) and the web app.
-Started via `viber gateway`. Nodes connect outbound to the gateway via WebSocket; the web app
+The central coordinator that routes messages between Vibers (daemons) and the web app.
+Started via `viber gateway`. Vibers connect outbound to the gateway via WebSocket; the web app
 (Viber Board) talks to the gateway via REST and SSE. This is distinct from the **Channels**
 server (enterprise channel webhooks) and from the **Skill Hub** (external skill registry).
 
@@ -71,21 +71,21 @@ the Gateway (central coordinator).
 
 The HTTP server that receives webhooks from enterprise channels (DingTalk, WeCom, Discord,
 Feishu). Started via `viber channels`. Implemented by `ChannelGateway` in `src/channels/gateway.ts`.
-Distinct from the Gateway (central coordinator for vibers).
+Distinct from the Gateway (central coordinator for Vibers).
 
 ## J
 
 ### Job
 
-A scheduled task defined as a YAML file that runs automatically on a cron timer. Jobs specify a schedule, a prompt, and optional configuration (model, skills, tools). They are stored per-viber in `~/.openviber/vibers/{id}/jobs/` or globally in `~/.openviber/jobs/`.
+A scheduled task defined as a YAML file that runs automatically on a cron timer. Jobs specify a schedule, a prompt, and optional configuration (model, skills, tools). They are stored per-task in `~/.openviber/vibers/{id}/jobs/` (where `{id}` is the task ID) or globally in `~/.openviber/jobs/`.
 
-When a job fires, the `JobScheduler` creates an `Agent` with the job's configuration and executes the prompt. Jobs can leverage skills for domain knowledge — for example, a health-check job uses the `antigravity` skill.
+When a job fires, the `JobScheduler` creates a `Task` (Agent) with the job's configuration and executes the prompt. Jobs can leverage skills for domain knowledge — for example, a health-check job uses the `antigravity` skill.
 
 See [Jobs](/docs/concepts/jobs) for full documentation.
 
 ### Job Scheduler
 
-The `JobScheduler` class that manages cron-based job execution. It reads YAML job files from disk, registers cron triggers via Croner, and creates Agent instances to execute job prompts on schedule.
+The `JobScheduler` class that manages cron-based job execution. It reads YAML job files from disk, registers cron triggers via Croner, and creates Task instances to execute job prompts on schedule.
 
 ## M
 
@@ -95,7 +95,7 @@ A single unit of communication within a conversation. Messages have:
 
 - **role**: `user`, `assistant`, or `system`
 - **content**: The message text
-- **metadata**: Additional information (timestamps, viber info)
+- **metadata**: Additional information (timestamps, task info)
 
 ### Metadata
 
@@ -103,10 +103,10 @@ Additional information attached to messages, Spaces, or artifacts. Used for trac
 
 ### Mode
 
-The operational mode for viber interactions:
+The operational mode for task interactions:
 
-- **Always Ask**: Viber asks before each action
-- **Viber Decides**: Viber acts within policy boundaries
+- **Always Ask**: Task asks before each action
+- **Task Decides** (or Viber Decides): Task acts within policy boundaries
 - **Always Execute**: Maximum autonomy, minimal interruption
 
 ## P
@@ -133,13 +133,13 @@ An LLM service provider. Supported providers:
 
 ### Skill
 
-A reusable bundle of domain knowledge that teaches a viber how to approach specific tasks. A skill is a directory containing a `SKILL.md` file (frontmatter + instructions) and optionally an `index.ts` that exports specialized tools.
+A reusable bundle of domain knowledge that teaches a task how to approach specific tasks. A skill is a directory containing a `SKILL.md` file (frontmatter + instructions) and optionally an `index.ts` that exports specialized tools.
 
 Skills are discovered from:
 - `~/.openviber/skills/` (user-defined)
 - `src/skills/` (built-in: antigravity, cursor-agent, codex-cli, github, tmux)
 
-Unlike tools (which provide actions), skills provide *knowledge and context* that gets injected into the agent's system prompt. Skills can also bundle their own tools — for example, the `github` skill provides `gh_list_issues`, `gh_create_pr`, etc.
+Unlike tools (which provide actions), skills provide *knowledge and context* that gets injected into the task's system prompt. Skills can also bundle their own tools — for example, the `github` skill provides `gh_list_issues`, `gh_create_pr`, etc.
 
 See [Skills](/docs/concepts/skills) for full documentation.
 
@@ -149,27 +149,25 @@ The `SkillRegistry` class that manages skill discovery, loading, and tool regist
 
 ### Space
 
-A working directory that vibers operate in. Spaces live at `~/openviber_spaces/` by default, but vibers can be pointed at any directory (e.g., an existing Git repo). A Space can be:
+A working directory that tasks operate in. Spaces live at `~/openviber_spaces/` by default, but tasks can be pointed at any directory (e.g., an existing Git repo). A Space can be:
 
 - A cloned Git repository (code projects)
 - A research folder (non-code work)
 - An output directory (reports, generated content)
 
-Multiple vibers can work on the same Space.
+Multiple tasks can work on the same Space.
 
 ## T
 
 ### Tool
 
-A capability that extends what vibers can do. Tools allow vibers to:
+A capability that extends what tasks can do. Tools allow tasks to:
 
 - Fetch external data
 - Read/write files
 - Search the web
 - Execute code
 - Interact with APIs
-
-## V
 
 ### Task
 
@@ -183,21 +181,23 @@ A role-scoped AI worker that runs on a Viber. Each task has its own:
 
 Tasks are configured through YAML files in `~/.openviber/vibers/`.
 
+## V
+
 ### Viber
 
 A machine running the OpenViber runtime that hosts one or more tasks. A Viber provides:
 
-- **Runtime** — The node runtime (daemon) process that executes viber tasks and connects to the Gateway
+- **Runtime** — The daemon process that executes tasks and connects to the Gateway
 - **Scheduler** — Cron-based job scheduling for automated tasks
 - **Credentials** — Shared account access for hosted tasks
-- **Config** — Identity and viber settings at `~/.openviber/` (lightweight, portable)
+- **Config** — Identity and settings at `~/.openviber/` (lightweight, portable)
 - **Spaces** — Working data at `~/openviber_spaces/` (repos, research, outputs)
 
-Nodes connect to the OpenViber Board via a one-time token command (`npx openviber connect --token ...`). Multiple tasks on one machine coordinate through external systems (GitHub, email) rather than direct inter-viber messaging.
+Vibers connect to the OpenViber Board via a one-time token command (`npx openviber connect --token ...`). Multiple tasks on one machine coordinate through external systems (GitHub, email) rather than direct inter-task messaging.
 
 ### ViberAgent
 
-The core class that orchestrates a viber's task execution. ViberAgent:
+The core class that orchestrates a task's execution. ViberAgent:
 
 - Processes user requests through an LLM
 - Coordinates tool calls and skill loading
@@ -214,8 +214,8 @@ The core class that orchestrates a viber's task execution. ViberAgent:
 |---------|-----------|
 | **Task** | A role-scoped AI worker with persona, goals, tools, and skills |
 | **Viber** | A machine running OpenViber, hosting one or more tasks |
-| **Space** | A persistent workspace container for a viber's work |
-| **Skill** | Domain knowledge bundle (`SKILL.md` + optional tools) that teaches agents domain-specific approaches |
+| **Space** | A persistent workspace container for a task's work |
+| **Skill** | Domain knowledge bundle (`SKILL.md` + optional tools) that teaches tasks domain-specific approaches |
 | **Tool** | An action capability (file ops, terminal, browser, search) |
 | **Job** | A YAML-defined scheduled task that runs on a cron timer |
 


### PR DESCRIPTION
Updated the documentation across the repository to align with the new terminology where "Viber" refers to the runtime/machine and "Task" refers to the worker/agent. This involved updating `README.md`, `docs/introduction.md`, `docs/concepts/viber.md`, `docs/concepts/jobs.md`, `docs/getting-started/quick-start.md`, `docs/getting-started/onboarding.md`, `docs/reference/glossary.md`, and `docs/design/viber.md`. Also clarified port usage in `README.md`.

---
*PR created automatically by Jules for task [1914117619206479421](https://jules.google.com/task/1914117619206479421) started by @hughlv*