### PR TITLE
Add `sys-telemetry` skill alias to improve skill/tool discoverability

### DIFF
--- a/src/skills/health.test.ts
+++ b/src/skills/health.test.ts
@@ -9,6 +9,12 @@ describe("skill health checks", () => {
     expect(result.summary).toContain("No automated health checks");
   });
 
+  it("marks sys-telemetry as available", async () => {
+    const result = await checkSkillHealth({ id: "sys-telemetry" });
+    expect(result.status).toBe("AVAILABLE");
+    expect(result.available).toBe(true);
+  });
+
   it("builds a report for the provided skill list", async () => {
     const report = await checkSkillsHealth([{ id: "mystery-skill" }]);
     expect(report.skills).toHaveLength(1);

--- a/src/skills/health.ts
+++ b/src/skills/health.ts
@@ -65,6 +65,7 @@ const DEFAULT_SKILL_IDS = [
   "gmail",
   "railway",
   "system-info",
+  "sys-telemetry",
   "terminal",
 ] as const;
 
@@ -519,6 +520,7 @@ const SKILL_CHECKERS: Record<
   gmail: checkGmailHealth,
   railway: checkRailwayHealth,
   "system-info": checkSystemInfoHealth,
+  "sys-telemetry": checkSystemInfoHealth,
   terminal: checkTerminalHealth,
 };
 

--- a/src/skills/index.ts
+++ b/src/skills/index.ts
@@ -8,6 +8,7 @@ import { getTools as getRailwayTools } from "./railway";
 import { getTools as getGmailTools } from "./gmail";
 import { getTools as getPlaygroundTools } from "./playground";
 import { getTools as getSystemInfoTools } from "./system-info";
+import { getTools as getSysTelemetryTools } from "./sys-telemetry";
 
 // Register default skills and their tools
 // This is called during module initialization to pre-register tools
@@ -31,5 +32,6 @@ export function registerDefaultSkills() {
   defaultRegistry.preRegisterTools("skill-playground", getPlaygroundTools());
   // Pre-register system-info tools (CPU, memory, disk, processes, network)
   defaultRegistry.preRegisterTools("system-info", getSystemInfoTools());
+  // Pre-register sys-telemetry alias tools (same surface as system-info)
+  defaultRegistry.preRegisterTools("sys-telemetry", getSysTelemetryTools());
 }
-

--- a/src/skills/sys-telemetry/SKILL.md
+++ b/src/skills/sys-telemetry/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: sys-telemetry
+version: 1.0.0
+description: Alias for system telemetry tools (CPU, memory, disk, processes, network).
+author: OpenViber
+---
+
+# Sys Telemetry Skill
+
+This is a compatibility alias for `system-info`.
+
+Use this skill when you need machine telemetry from the local host:
+- CPU usage and core stats
+- Memory usage
+- Disk capacity and free space
+- Top processes by CPU/memory
+- Network interfaces and optional DNS connectivity check
+
+## Tools
+
+This skill exposes the same tools as `system-info`:
+- `system_info`
+- `system_processes`
+- `system_network`

--- a/src/skills/sys-telemetry/index.ts
+++ b/src/skills/sys-telemetry/index.ts
@@ -1,0 +1,7 @@
+/**
+ * sys-telemetry skill alias.
+ *
+ * Re-exports system telemetry tools from the system-info skill so users can
+ * enable either skill id and get the same tool surface.
+ */
+export { getTools } from "../system-info";


### PR DESCRIPTION
### Motivation
- Users may refer to host telemetry as “sys telemetry”, so the LLM should be able to discover a matching skill id by name. 
- Ensure the same tool surface for telemetry is available whether the agent enables `system-info` or the more natural `sys-telemetry` alias. 
- Make tools invokable even in bundled runtimes where dynamic `.ts` imports may be unavailable by pre-registering the alias's tools.

### Description
- Added a new built-in skill `sys-telemetry` with `SKILL.md` and `index.ts` that re-exports `getTools` from `system-info` so it exposes `system_info`, `system_processes`, and `system_network` tools (`src/skills/sys-telemetry/`).
- Pre-registered the alias in `registerDefaultSkills()` by updating `src/skills/index.ts` so `sys-telemetry` tools are available even without dynamic imports. 
- Included `sys-telemetry` in the default health/skill lists and mapped it to the same checker as `system-info` in `src/skills/health.ts`. 
- Added a small health test that asserts `sys-telemetry` resolves as `AVAILABLE` in `src/skills/health.test.ts`.

### Testing
- Ran `pnpm vitest run src/skills/health.test.ts src/skills/registry.test.ts` and the targeted tests passed (`2 files`, `4 tests` all succeeded). 
- Also executed `pnpm vitest run src/skills/health.test.ts src/skills/registry.test.ts` locally as a quick verification and saw the new health assertion pass. 
- Ran `pnpm typecheck` which failed due to an existing unrelated typing error in `src/channels/builtin.ts` (missing `capabilities` on a `ChannelFactory`), not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ff078a9ac832e8d4f05d64d1f16d8)