### PR TITLE
fix(skills): pre-register gemini-cli tools for daemon runtime

### DIFF
--- a/src/skills/index.test.ts
+++ b/src/skills/index.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { defaultRegistry } from "./registry";
+import { registerDefaultSkills } from "./index";
+
+describe("registerDefaultSkills", () => {
+  it("pre-registers gemini-cli tools so runtime can load them without SKILL.md discovery", async () => {
+    registerDefaultSkills();
+
+    const tools = await defaultRegistry.getTools("gemini-cli");
+
+    expect(tools).toBeDefined();
+    expect(Object.keys(tools)).toContain("gemini_run");
+  });
+});

--- a/src/skills/index.ts
+++ b/src/skills/index.ts
@@ -2,6 +2,7 @@ import { defaultRegistry } from "./registry";
 import { getTools as getAntigravityTools } from "./antigravity";
 import { getTools as getCursorAgentTools } from "./cursor-agent";
 import { getTools as getCodexCliTools } from "./codex-cli";
+import { getTools as getGeminiCliTools } from "./gemini-cli";
 import { getTools as getGithubTools } from "./github";
 import { getTools as getTerminalTools } from "./terminal";
 import { getTools as getRailwayTools } from "./railway";
@@ -19,6 +20,8 @@ export function registerDefaultSkills() {
   defaultRegistry.preRegisterTools("cursor-agent", getCursorAgentTools());
   // Pre-register codex-cli tools (run Codex CLI via non-interactive codex exec)
   defaultRegistry.preRegisterTools("codex-cli", getCodexCliTools());
+  // Pre-register gemini-cli tools (run Gemini CLI via headless gemini --prompt)
+  defaultRegistry.preRegisterTools("gemini-cli", getGeminiCliTools());
   // Pre-register github tools (gh CLI for issues, PRs, branches)
   defaultRegistry.preRegisterTools("github", getGithubTools());
   // Pre-register terminal tools (persistent terminal sessions, backed by tmux)
@@ -32,4 +35,3 @@ export function registerDefaultSkills() {
   // Pre-register system-info tools (CPU, memory, disk, processes, network)
   defaultRegistry.preRegisterTools("system-info", getSystemInfoTools());
 }
-


### PR DESCRIPTION
### Motivation
- Ensure the daemon/CLI runtime pre-registers the `gemini-cli` built-in skill so its tools are available in packaged/bundled runtimes without relying on dynamic `.ts`/`SKILL.md` discovery.

### Description
- Import `getGeminiCliTools` and add `defaultRegistry.preRegisterTools("gemini-cli", getGeminiCliTools())` in `src/skills/index.ts` so `gemini-cli` is pre-registered during startup.
- Add `src/skills/index.test.ts` with a focused test that calls `registerDefaultSkills()` and asserts `defaultRegistry.getTools("gemini-cli")` exposes `gemini_run`.

### Testing
- Ran `pnpm vitest run src/skills/index.test.ts src/skills/registry.test.ts` and both tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ff0160c9c832e9c2dfb92012aff72)