### PR TITLE
Refactor AI provider to use Dynamic Registry and compare architecture with Nanobot

### DIFF
--- a/ARCHITECTURE_COMPARISON.md
+++ b/ARCHITECTURE_COMPARISON.md
@@ -73,13 +73,30 @@ This document provides a detailed architectural comparison between **OpenViber**
 ### OpenViber
 - **Channel Abstraction**: Features a strict `Channel` interface that decouples the agent core from communication protocols.
 - **Unified Gateway**: The `ChannelGateway` manages multiple channels (Discord, Feishu, Telegram, Web) simultaneously, handling routing and streaming with a unified event model.
+- **Dynamic Provider Registry**: Implements a `ProviderRegistry` pattern that allows new AI providers (e.g., Google, Mistral) to be registered dynamically at runtime without modifying core code.
+  ```typescript
+  // Registering a new provider in OpenViber
+  providerRegistry.register("google", (config) => createGoogleGenerativeAI(config));
+  ```
 - **Example**: Telegram support was added cleanly by implementing a single class (`TelegramChannel`) and registering it, without touching the core agent logic.
 
 ### Nanobot
 - **Direct Integration**: Channels often require more direct integration into the main loop or configuration parsing logic.
-- **Provider Registry**: While modular, it relies on python-specific class introspection which can be fragile.
+- **Provider Registry**: While modular, it relies on python-specific class introspection which can be less explicit than a typed registry.
 
 **Verdict**: OpenViber's interface-based design allows for safer and more predictable extensions.
+
+## 7. Platform vs Script
+
+### OpenViber (Platform)
+- **Feature-Rich (~34k lines)**: Includes a Web UI, persistent Gateway server, Daemon with telemetry, and robust task orchestration. It is designed as a **long-running platform** for autonomous agents.
+- **Distributed Ready**: Architecture explicitly supports multiple "Viber" nodes connecting to a central command center.
+
+### Nanobot (Script)
+- **Ultra-Lightweight (~4k lines)**: Excellent for quick prototyping and research experiments where minimal code is desired.
+- **Local Focus**: Primarily designed for single-machine, single-user scenarios.
+
+**Verdict**: While Nanobot is lighter, OpenViber provides the necessary infrastructure for production agent deployments.
 
 ## Conclusion
 

--- a/src/viber/registry.test.ts
+++ b/src/viber/registry.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from "vitest";
+import { providerRegistry, getModelProvider } from "./provider";
+
+describe("ProviderRegistry", () => {
+  it("should have default providers registered", () => {
+    expect(providerRegistry.has("anthropic")).toBe(true);
+    expect(providerRegistry.has("openai")).toBe(true);
+    expect(providerRegistry.has("deepseek")).toBe(true);
+    expect(providerRegistry.has("openrouter")).toBe(true);
+  });
+
+  it("should allow registering a custom provider", () => {
+    const customProviderName = "custom-test";
+    const mockFactory = vi.fn().mockReturnValue(() => ({}));
+
+    providerRegistry.register(customProviderName, mockFactory);
+
+    expect(providerRegistry.has(customProviderName)).toBe(true);
+
+    // Test retrieval
+    const config = { provider: customProviderName, modelName: "test-model" };
+    const provider = getModelProvider(config);
+
+    expect(mockFactory).toHaveBeenCalledWith(config);
+    expect(provider).toBeDefined();
+  });
+
+  it("should throw error for unknown provider", () => {
+    const config = { provider: "unknown-provider", modelName: "test-model" };
+    expect(() => getModelProvider(config)).toThrow(/is not configured/);
+  });
+});


### PR DESCRIPTION
Refactored `src/viber/provider.ts` to use a `ProviderRegistry` class, allowing dynamic registration of AI providers instead of a hardcoded switch statement. This improves extensibility and aligns with the project's goal of an elegant, modular architecture. Also updated `ARCHITECTURE_COMPARISON.md` to detail the differences between OpenViber (Platform) and Nanobot (Script), highlighting the new registry and other architectural advantages.

---
*PR created automatically by Jules for task [9892545022423975148](https://jules.google.com/task/9892545022423975148) started by @hughlv*