### PR TITLE
docs: update outdated viber documentation and terminology

### DIFF
--- a/docs/concepts/viber.md
+++ b/docs/concepts/viber.md
@@ -30,6 +30,27 @@ You:   "Go ahead"
 Task:  On it. You can watch in the terminal panel...
 ```
 
+## The Viber Runtime
+
+A **Viber** is a single machine running the OpenViber runtime. It provides:
+
+- **Scheduler** — Runs tasks on cron schedules (daily research, weekly reports)
+- **Credentials** — Shared account access for all tasks on the Viber
+- **Config** — Identity and settings at `~/.openviber/` (lightweight, portable)
+- **Spaces** — Working data at `~/openviber_spaces/` (repos, research, outputs)
+
+### Connecting a Viber
+
+From the OpenViber Board, click **Add Viber** to generate a start command:
+
+```bash
+npx openviber start --token eyJub2RlIjoiYTFiMmMz...
+```
+
+This bootstraps the Viber, creates `~/.openviber/`, and connects to the Board — no inbound ports needed.
+
+Multiple tasks coordinate through **external systems** (GitHub issues, email) rather than talking to each other directly. This keeps everything simple and stateless.
+
 ## Tasks
 
 A **Task** is the unit of work in OpenViber. It combines:
@@ -82,18 +103,6 @@ You can manage built-in and custom intent templates in **Settings → Intents**:
 - replicate built-in templates into editable user templates
 - keep intent instructions aligned with your team workflows
 
-## What Makes a Viber
-
-A Viber combines three elements that no chat-only AI has:
-
-| Element                 | What It Gives You                                                            |
-| ----------------------- | ---------------------------------------------------------------------------- |
-| **Persona & Goals**     | Role focus — configured per-task, allowing the Viber to switch contexts      |
-| **Machine Runtime**     | Real execution — terminal, browser, files, apps on your machine              |
-| **Identity & Accounts** | Agency — acts on your behalf across GitHub, email, cloud services            |
-
-This is what separates a Viber from a chatbot: it doesn't just answer questions, it **does the work**.
-
 ## Working Modes
 
 | Mode               | When to Use                                                    |
@@ -112,27 +121,6 @@ Your Viber works autonomously but you always have oversight:
 - **Intervene** — Pause, redirect, or stop at any point through chat
 - **Approve** — Sensitive actions require explicit permission
 - **Audit** — Every action is logged; budget limits prevent runaway costs
-
-## The Viber Runtime
-
-A **Viber** is a single machine running the OpenViber runtime. It provides:
-
-- **Scheduler** — Runs tasks on cron schedules (daily research, weekly reports)
-- **Credentials** — Shared account access for all tasks on the Viber
-- **Config** — Identity and settings at `~/.openviber/` (lightweight, portable)
-- **Spaces** — Working data at `~/openviber_spaces/` (repos, research, outputs)
-
-### Connecting a Viber
-
-From the OpenViber Board, click **Add Viber** to generate a one-liner:
-
-```bash
-npx openviber connect --token eyJub2RlIjoiYTFiMmMz...
-```
-
-This bootstraps the Viber, creates `~/.openviber/`, and connects to the Board — no inbound ports needed.
-
-Multiple tasks coordinate through **external systems** (GitHub issues, email) rather than talking to each other directly. This keeps everything simple and stateless.
 
 ## Next Steps
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -61,7 +61,7 @@ openviber channels
 
 | Concept | What It Is |
 |---------|------------|
-| **Viber** | Your machine (the AI Worker) running the OpenViber daemon — executes tasks |
+| **Viber** | Your machine running the OpenViber daemon — executes tasks |
 | **Task** | A role-scoped unit of work assigned to a Viber |
 | **Tools** | Actions the Viber can take (file, search, web, browser, desktop, schedule, notify) |
 | **Skills** | Domain knowledge bundles (`SKILL.md` + optional tools) — antigravity, cursor-agent, codex-cli, github, terminal |
@@ -74,7 +74,7 @@ OpenViber supports three levels of autonomy:
 | Mode | Behavior |
 |------|----------|
 | **Always Ask** | Task asks before each action — you approve everything |
-| **Task Decides** | Task acts within policy, escalates risky actions (also known as "Viber Decides") |
+| **Task Decides** | Task acts within policy, escalates risky actions |
 | **Always Execute** | Maximum autonomy, intervene by exception |
 
 Start with "Always Ask" and gradually increase autonomy as you build trust.


### PR DESCRIPTION
This PR updates the documentation to reflect the current state of the project. 

Key changes:
- `docs/concepts/viber.md`: Corrected the CLI command for connecting a viber (using `start` instead of `connect`), removed duplicate content, and clarified the roles of Viber vs Task.
- `docs/introduction.md`: Standardized terminology (Task Decides vs Viber Decides) and clarified the definition of a Viber.

These changes ensure the documentation is accurate and helpful for new users.

---
*PR created automatically by Jules for task [17420057280736434634](https://jules.google.com/task/17420057280736434634) started by @hughlv*