### PR TITLE
fix(web): resolve svelte-check errors, accessibility issues, and add chat image-attachment support

### DIFF
--- a/web/src/lib/components/docs/index.ts
+++ b/web/src/lib/components/docs/index.ts
@@ -1,4 +1,4 @@
-export { default as Aside } from "./aside.svelte";
-export { default as Card } from "./card.svelte";
+export { default as Aside } from "./Aside.svelte";
+export { default as Card } from "./Card.svelte";
 export { default as CardGrid } from "./card-grid.svelte";
 export { default as LinkCard } from "./link-card.svelte";

--- a/web/src/lib/components/template-params.svelte
+++ b/web/src/lib/components/template-params.svelte
@@ -44,7 +44,7 @@
           <Select
             id={inputId}
             value={values[param.id] ?? ""}
-            on:change={(e) =>
+            onchange={(e) =>
               onChange(
                 param.id,
                 (e.currentTarget as HTMLSelectElement).value,
@@ -59,7 +59,7 @@
             id={inputId}
             value={values[param.id] ?? ""}
             placeholder={param.placeholder}
-            on:input={(e) =>
+            oninput={(e) =>
               onChange(
                 param.id,
                 (e.currentTarget as HTMLInputElement).value,

--- a/web/src/lib/server/gateway.ts
+++ b/web/src/lib/server/gateway.ts
@@ -54,6 +54,16 @@ export interface NodeSkillInfo {
   status: "AVAILABLE" | "NOT_AVAILABLE" | "UNKNOWN";
   /** Human-readable summary (e.g. "Missing: gh CLI") */
   healthSummary?: string;
+  /** Optional detailed health checks reported by node */
+  checks?: Array<{
+    id: string;
+    label: string;
+    ok: boolean;
+    required?: boolean;
+    message?: string;
+    hint?: string;
+    actionType?: string;
+  }>;
 }
 
 /** Summary machine resource metrics (from heartbeat) */
@@ -301,7 +311,13 @@ export const gatewayClient = {
     nodeId?: string,
     messages?: { role: string; content: string }[],
     environment?: ViberEnvironmentContext,
-    settings?: { primaryCodingCli?: string; channelIds?: string[] },
+    settings?: {
+      primaryCodingCli?: string;
+      channelIds?: string[];
+      proxyUrl?: string;
+      proxyEnabled?: boolean;
+      skills?: string[];
+    },
     oauthTokens?: Record<string, { accessToken: string; refreshToken?: string | null }>,
     model?: string,
   ): Promise<{ viberId: string; nodeId: string } | null> {
@@ -348,7 +364,12 @@ export const gatewayClient = {
     messages: { role: string; content: string }[],
     goal?: string,
     environment?: ViberEnvironmentContext,
-    settings?: { primaryCodingCli?: string },
+    settings?: {
+      primaryCodingCli?: string;
+      proxyUrl?: string;
+      proxyEnabled?: boolean;
+      skills?: string[];
+    },
     oauthTokens?: Record<string, { accessToken: string; refreshToken?: string | null }>,
     model?: string,
   ): Promise<{ viberId: string; nodeId: string } | null> {

--- a/web/src/routes/(viberboard)/+layout.svelte
+++ b/web/src/routes/(viberboard)/+layout.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { goto } from "$app/navigation";
   import { page } from "$app/stores";
   import { onMount } from "svelte";
   import * as Sidebar from "$lib/components/ui/sidebar";
@@ -322,9 +323,9 @@
                     <HoverCard.Root openDelay={400} closeDelay={100}>
                       <HoverCard.Trigger class="min-w-0 w-full">
                         <Sidebar.MenuButton
-                          href={`/tasks/${task.id}`}
                           isActive={pathname.startsWith(`/tasks/${task.id}`)}
                           class="min-h-8 gap-2 rounded-lg px-2.5 py-1.5 text-[13px] font-medium text-sidebar-foreground/85 hover:bg-sidebar-accent data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-foreground pr-8 overflow-hidden"
+                          onclick={() => goto(`/tasks/${task.id}`)}
                         >
                           <!-- Status icon / Unpin toggle on hover -->
                           <button

--- a/web/src/routes/(viberboard)/tasks/[id]/+page.svelte
+++ b/web/src/routes/(viberboard)/tasks/[id]/+page.svelte
@@ -23,7 +23,9 @@
     X,
   } from "@lucide/svelte";
   import { marked } from "marked";
-  import ChatComposer from "$lib/components/chat-composer.svelte";
+  import ChatComposer, {
+    type ComposerImageAttachment,
+  } from "$lib/components/chat-composer.svelte";
   import * as Resizable from "$lib/components/ui/resizable";
   import * as Sheet from "$lib/components/ui/sheet";
   import * as Dialog from "$lib/components/ui/dialog";
@@ -486,6 +488,7 @@
   let dbMessages = $state<Message[]>([]);
   let loading = $state(true);
   let inputValue = $state("");
+  let imageAttachments = $state<ComposerImageAttachment[]>([]);
   let selectedModelId = $state("");
   let selectedSkillIds = $state<string[]>([]);
   let composerEnvironments = $state<ComposerEnvInfo[]>([]);
@@ -745,7 +748,7 @@
 
   async function sendMessage(overrideContent?: string) {
     const content = (overrideContent ?? inputValue).trim();
-    if (!content || sending || viber?.nodeConnected !== true) return;
+    if ((content.length === 0 && imageAttachments.length === 0) || sending || viber?.nodeConnected !== true) return;
 
     const unavailableSelected = (viber?.skills ?? []).filter(
       (skill) =>
@@ -757,7 +760,9 @@
     }
 
     chatError = null; // Clear previous error on retry
+    const pendingAttachments = [...imageAttachments];
     inputValue = "";
+    imageAttachments = [];
     sending = true;
     sessionStartedAt = Date.now();
 
@@ -765,7 +770,19 @@
     void fetch(`/api/tasks/${viber.id}/messages`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ role: "user", content }),
+      body: JSON.stringify({
+        role: "user",
+        content,
+        parts: [
+          ...(content ? [{ type: "text", text: content }] : []),
+          ...pendingAttachments.map((attachment) => ({
+            type: "file",
+            mediaType: attachment.mediaType,
+            url: attachment.dataUrl,
+            name: attachment.name,
+          })),
+        ],
+      }),
     }).catch(() => {
       /* ignore */
     });
@@ -842,7 +859,13 @@
     // Send via AI SDK Chat class (handles streaming automatically)
     try {
       if (chat) {
-        await chat.sendMessage({ text: content });
+        await chat.sendMessage({
+          text: content,
+          files: pendingAttachments.map((attachment) => ({
+            type: attachment.mediaType,
+            data: attachment.dataUrl,
+          })),
+        } as any);
       }
     } catch (error) {
       console.error("Failed to send message:", error);
@@ -1267,6 +1290,13 @@
                             <div class="message-markdown">
                               {@html renderMarkdown((part as any).text)}
                             </div>
+                          {:else if part.type === "file" && (part as any).mediaType?.startsWith("image/") && (part as any).url}
+                            <img
+                              src={(part as any).url}
+                              alt={(part as any).name || "Uploaded image"}
+                              class="mt-2 max-h-64 rounded-lg border border-border object-contain"
+                              loading="lazy"
+                            />
                           {/if}
                         {/each}
                         <p class="text-[11px] mt-1.5 opacity-40 tracking-wide">
@@ -1389,6 +1419,7 @@
           {/if}
           <ChatComposer
             bind:value={inputValue}
+            bind:imageAttachments
             bind:inputElement={inputEl}
             bind:selectedModelId
             bind:selectedEnvironmentId
@@ -1397,7 +1428,6 @@
               : "Viber is offline"}
             disabled={viber?.nodeConnected !== true}
             {sending}
-            nodes={[]}
             environments={composerEnvironments}
             skills={viber?.skills ?? []}
             bind:selectedSkillIds

--- a/web/src/routes/(viberboard)/vibers/+page.svelte
+++ b/web/src/routes/(viberboard)/vibers/+page.svelte
@@ -349,9 +349,7 @@
                       <span>created {formatTimeAgo(viber.created_at)}</span>
                     </CardDescription>
                     {#if getConfigSyncBadge(viber.config_sync_state)}
-                      {@const badge = getConfigSyncBadge(
-                        viber.config_sync_state,
-                      )}
+                      {@const badge = getConfigSyncBadge(viber.config_sync_state)!}
                       <div class="mt-1.5">
                         <span
                           class={`inline-flex items-center rounded-md px-1.5 py-0.5 text-[10px] font-medium ${badge.class}`}

--- a/web/src/routes/api/vibers/[id]/config-sync-state/+server.ts
+++ b/web/src/routes/api/vibers/[id]/config-sync-state/+server.ts
@@ -11,6 +11,9 @@ import { updateConfigSyncState } from "$lib/server/vibers";
 
 export const PUT: RequestHandler = async ({ params, request }) => {
   const viberId = params.id;
+  if (!viberId) {
+    return json({ error: "Missing viber id" }, { status: 400 });
+  }
 
   // Authenticate via gateway API token or service role
   const authHeader = request.headers.get("authorization");

--- a/web/src/routes/settings/general/+page.svelte
+++ b/web/src/routes/settings/general/+page.svelte
@@ -537,6 +537,7 @@
               </label>
               <button
                 id="proxy-enabled"
+                aria-label="Enable proxy"
                 type="button"
                 role="switch"
                 aria-checked={editProxyEnabled}
@@ -549,7 +550,7 @@
                   class="pointer-events-none inline-block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform duration-200 ease-in-out {editProxyEnabled
                     ? 'translate-x-5'
                     : 'translate-x-0'}"
-                />
+                ></span>
               </button>
             </div>
 


### PR DESCRIPTION
### Motivation
- Clear a set of failing Svelte/typecheck errors so `pnpm --dir web check` passes and the web workspace baseline is healthy. 
- Remove incorrect/unsupported usages and tighten types where runtime code relied on fields or props that the TypeScript types did not declare. 
- Improve accessibility and UX for the chat composer by adding basic image-attachment support and keyboard/resize handling. 

### Description
- Fixed component barrel exports casing in `web/src/lib/components/docs/index.ts` to match actual filenames (`Aside.svelte`, `Card.svelte`). 
- Switched Svelte event handlers in `web/src/lib/components/template-params.svelte` from legacy `on:...` to Svelte 5 DOM handlers (`onchange` / `oninput`) to satisfy current typing. 
- Expanded gateway client typings in `web/src/lib/server/gateway.ts` to include optional node `checks` and added `proxyUrl`, `proxyEnabled`, and `skills` to `settings` shapes used by `createTask`/`sendMessage`. 
- Replaced unsupported `href` prop usage on `Sidebar.MenuButton` with `onclick={() => goto(...)}` and added `goto` import in `web/src/routes/(viberboard)/+layout.svelte`. 
- Added guard for missing route param in `web/src/routes/api/vibers/[id]/config-sync-state/+server.ts`. 
- Tightened nullable badge logic in `web/src/routes/(viberboard)/vibers/+page.svelte` to avoid invalid access when `getConfigSyncBadge` can return null. 
- Addressed accessibility/warning issues in settings proxy toggle by adding `aria-label` and converting a self-closing `<span />` to an explicit closing tag in `web/src/routes/settings/general/+page.svelte`. 
- Added image attachment support to the chat composer in `web/src/lib/components/chat-composer.svelte` (attachment type, file input, paste handling, inline previews, remove action, textarea auto-resize, and `canSend` logic). 
- Propagated chat image changes into the task page in `web/src/routes/(viberboard)/tasks/[id]/+page.svelte` by importing the attachment type, binding `imageAttachments`, persisting file parts when saving user messages, rendering uploaded images in messages, and sending files to the AI transport. 
- Adjusted `web/src/routes/(viberboard)/tasks/[id]/+page.svelte` to remove unsupported `nodes` prop usage with `ChatComposer`. 

### Testing
- Ran `pnpm --dir web check` and the workspace Svelte/typecheck diagnostics returned zero errors and zero warnings. (Succeeded) 
- Started the dev server with `cd web && E2E_TEST_MODE=true pnpm dev --host 0.0.0.0 --port 6006` and verified the E2E test-mode endpoint with `curl http://localhost:6006/auth/test-session`. (Server started and `auth/test-session` returned the expected test-mode JSON) 
- Executed a Playwright script to capture a UI screenshot after fixes and produced a screenshot artifact to validate the chat composer UI. (Screenshot artifact produced)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ff1cf72c4832e80f03bafc0deee36)