### PR TITLE
fix(web): require APP_URL for OAuth redirect URIs

### DIFF
--- a/web/src/lib/server/auth.ts
+++ b/web/src/lib/server/auth.ts
@@ -9,10 +9,18 @@ const ACCESS_TOKEN_COOKIE = "openviber_sb_access_token";
 const REFRESH_TOKEN_COOKIE = "openviber_sb_refresh_token";
 const GITHUB_TOKEN_COOKIE = "openviber_gh_token";
 
-const APP_URL = env.APP_URL || "http://localhost:6006";
+const APP_URL = env.APP_URL?.trim() || "";
 const SUPABASE_URL = env.SUPABASE_URL;
 const SUPABASE_ANON_KEY = env.SUPABASE_ANON_KEY;
 const SUPABASE_SERVICE_ROLE_KEY = env.SUPABASE_SERVICE_ROLE_KEY;
+
+function requireAppUrl(): string {
+  if (!APP_URL) {
+    throw new Error("APP_URL is required for OAuth callbacks.");
+  }
+
+  return APP_URL;
+}
 
 /**
  * E2E test mode — set E2E_TEST_MODE=true in .env to enable.
@@ -105,7 +113,7 @@ function createPkcePair() {
  * Returns true when Supabase OAuth is configured for this deployment.
  */
 export function supabaseAuthConfigured() {
-  return Boolean(SUPABASE_URL && SUPABASE_ANON_KEY);
+  return Boolean(SUPABASE_URL && SUPABASE_ANON_KEY && APP_URL);
 }
 
 /**
@@ -115,8 +123,7 @@ export function getSupabaseGitHubAuthUrl(nextPath = "/") {
   const { supabaseUrl } = requireSupabaseAuthConfig();
   const state = randomBytes(24).toString("hex");
   const { verifier, challenge } = createPkcePair();
-
-  const callbackUrl = new URL(`${APP_URL}/auth/callback`);
+  const callbackUrl = new URL(`/auth/callback`, requireAppUrl());
   callbackUrl.searchParams.set("next", nextPath);
   callbackUrl.searchParams.set("app_state", state);
 

--- a/web/src/routes/auth/google/+server.ts
+++ b/web/src/routes/auth/google/+server.ts
@@ -11,7 +11,7 @@ import { getGoogleAuthUrl, googleOAuthConfigured } from "$lib/server/oauth";
 
 const GOOGLE_OAUTH_STATE_COOKIE = "openviber_google_oauth_state";
 
-export const GET: RequestHandler = async ({ cookies, locals }) => {
+export const GET: RequestHandler = async ({ cookies, locals, url }) => {
   if (!googleOAuthConfigured()) {
     return new Response("Google OAuth is not configured on this server.", { status: 503 });
   }
@@ -26,7 +26,7 @@ export const GET: RequestHandler = async ({ cookies, locals }) => {
   cookies.set(GOOGLE_OAUTH_STATE_COOKIE, state, {
     path: "/",
     httpOnly: true,
-    secure: true,
+    secure: url.protocol === "https:",
     sameSite: "lax",
     maxAge: 600, // 10 minutes
   });


### PR DESCRIPTION
### Motivation
- OAuth redirect URIs were being constructed from a runtime request origin (or falling back to localhost), which can break provider and Supabase allowlists behind proxies or in deployed environments; the goal is to make redirect URIs deterministic and match config.

### Description
- Require a configured `APP_URL` (trimmed) and add `requireAppUrl()` helpers in `web/src/lib/server/auth.ts` and `web/src/lib/server/oauth.ts` so server-side OAuth helpers always build callbacks from the canonical app URL instead of runtime origin.
- Make Supabase and Google OAuth availability checks include `APP_URL` by updating `supabaseAuthConfigured()` and `googleOAuthConfigured()`.
- Simplify routes to call the new helper signatures (remove passing `url.origin`): updated `web/src/routes/auth/github/+server.ts`, `web/src/routes/auth/google/+server.ts`, and `web/src/routes/auth/google/callback/+server.ts` to use the canonical helpers and to set cookie `secure` flag based on `url.protocol`.
- Keep PKCE/state handling intact for Supabase GitHub flow and Google flow but ensure the `redirect_uri` used during token exchange is built from the required `APP_URL`.

### Testing
- Ran `pnpm --filter @openviber/web check`, which executes `svelte-kit sync && svelte-check`, and `svelte-check` reported `0 errors and 0 warnings` (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991122d6b54832e989557382a59e6eb)