### PR TITLE
fix(web): improve mobile responsiveness on landing and settings pages

### DIFF
--- a/verify_mobile.py
+++ b/verify_mobile.py
@@ -1,0 +1,58 @@
+from playwright.sync_api import sync_playwright
+import os
+import time
+
+# List of pages to test
+PAGES = [
+    "/",
+    "/landing",
+    "/docs",
+    "/hub",
+    "/login",
+    "/onboarding",
+    "/observability",
+    "/tasks",
+    "/vibers",
+    "/settings/general"
+]
+
+BASE_URL = "http://localhost:6006"
+
+def verify_mobile_pages():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        # Emulate a mobile device (iPhone 12 Pro)
+        context = browser.new_context(
+            viewport={"width": 390, "height": 844},
+            user_agent="Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Mobile/15E148 Safari/604.1",
+            device_scale_factor=3,
+            is_mobile=True,
+            has_touch=True
+        )
+        page = context.new_page()
+
+        for path in PAGES:
+            url = f"{BASE_URL}{path}"
+            print(f"Testing {url}...")
+            try:
+                page.goto(url, timeout=60000)
+                # Wait for network idle to ensure assets are loaded
+                try:
+                    page.wait_for_load_state("networkidle", timeout=10000)
+                except:
+                    print(f"Network idle timeout for {path}, proceeding...")
+
+                # Take screenshot
+                filename = path.replace("/", "_").strip("_")
+                if not filename:
+                    filename = "root"
+                screenshot_path = f"verification/mobile/{filename}.png"
+                page.screenshot(path=screenshot_path, full_page=True)
+                print(f"Saved screenshot to {screenshot_path}")
+            except Exception as e:
+                print(f"Error testing {path}: {e}")
+
+        browser.close()
+
+if __name__ == "__main__":
+    verify_mobile_pages()

--- a/web/src/routes/(public)/landing/+page.svelte
+++ b/web/src/routes/(public)/landing/+page.svelte
@@ -308,7 +308,7 @@
         {#if data.user}
           <a
             href="/"
-            class="cta-primary group inline-flex items-center gap-3 rounded-full bg-primary px-12 py-5 text-lg font-bold text-primary-foreground shadow-[0_0_40px_hsl(var(--primary)/0.4)] transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_0_60px_hsl(var(--primary)/0.5)]"
+            class="cta-primary group inline-flex items-center gap-3 rounded-full bg-primary px-6 py-3 text-base font-bold text-primary-foreground shadow-[0_0_40px_hsl(var(--primary)/0.4)] transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_0_60px_hsl(var(--primary)/0.5)] md:px-12 md:py-5 md:text-lg"
           >
             Go to Viberboard
             <ArrowRight
@@ -318,7 +318,7 @@
         {:else if data.supabaseAuthEnabled}
           <a
             href={githubAuthUrl}
-            class="cta-primary group inline-flex items-center gap-3 rounded-full bg-primary px-12 py-5 text-lg font-bold text-primary-foreground shadow-[0_0_40px_hsl(var(--primary)/0.4)] transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_0_60px_hsl(var(--primary)/0.5)]"
+            class="cta-primary group inline-flex items-center gap-3 rounded-full bg-primary px-6 py-3 text-base font-bold text-primary-foreground shadow-[0_0_40px_hsl(var(--primary)/0.4)] transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_0_60px_hsl(var(--primary)/0.5)] md:px-12 md:py-5 md:text-lg"
           >
             <svg
               class="size-5"
@@ -338,7 +338,7 @@
         {/if}
         <a
           href="/docs"
-          class="inline-flex items-center gap-2 rounded-full border border-border/80 bg-background/60 px-8 py-4 text-base font-medium text-foreground backdrop-blur-sm transition-all duration-300 hover:-translate-y-0.5 hover:border-primary/40 hover:bg-accent/80"
+          class="inline-flex items-center gap-2 rounded-full border border-border/80 bg-background/60 px-5 py-3 text-sm font-medium text-foreground backdrop-blur-sm transition-all duration-300 hover:-translate-y-0.5 hover:border-primary/40 hover:bg-accent/80 md:px-8 md:py-4 md:text-base"
         >
           Read the Docs
         </a>
@@ -428,7 +428,7 @@
         </div>
 
         <div class="relative rounded-xl border border-border/50 bg-card/50 backdrop-blur-sm p-2 shadow-2xl">
-           <div class="rounded-lg bg-[#0d1117] p-4 font-mono text-sm shadow-inner min-h-[300px]">
+           <div class="rounded-lg bg-[#0d1117] p-4 font-mono text-sm shadow-inner min-h-[300px] overflow-x-auto">
              <div class="flex gap-1.5 mb-4">
                <div class="size-3 rounded-full bg-red-500/80"></div>
                <div class="size-3 rounded-full bg-yellow-500/80"></div>

--- a/web/src/routes/settings/general/+page.svelte
+++ b/web/src/routes/settings/general/+page.svelte
@@ -497,13 +497,13 @@
             <select
               id="chat-model"
               bind:value={editChatModel}
-              class="w-full h-9 rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 focus:ring-offset-background"
+              class="w-full h-9 rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 focus:ring-offset-background max-w-full text-ellipsis"
             >
               {#each MODEL_OPTIONS as opt (opt.id)}
                 <option value={opt.id}>{opt.label}</option>
               {/each}
             </select>
-            <p class="mt-2 text-[11px] text-muted-foreground/60">
+            <p class="mt-2 text-[11px] text-muted-foreground/60 break-words">
               Uses <code class="rounded bg-muted px-1 py-0.5 text-[10px]"
                 >provider/model-name</code
               > format. The model must be accessible via your configured API keys
@@ -604,7 +604,7 @@
             <select
               id="primary-coding-cli"
               bind:value={editPrimaryCodingCli}
-              class="w-full h-9 rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 focus:ring-offset-background"
+              class="w-full h-9 rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 focus:ring-offset-background max-w-full text-ellipsis"
             >
               <option value="">Let agent choose</option>
               {#each codingCliOptions as opt (opt.id)}
@@ -636,13 +636,13 @@
             <select
               id="timezone"
               bind:value={editTimezone}
-              class="w-full h-9 rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 focus:ring-offset-background"
+              class="w-full h-9 rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 focus:ring-offset-background max-w-full text-ellipsis"
             >
               {#each POPULAR_TIMEZONES as tz (tz.id)}
                 <option value={tz.id}>{tz.label}</option>
               {/each}
             </select>
-            <p class="mt-2 text-[11px] text-muted-foreground/60">
+            <p class="mt-2 text-[11px] text-muted-foreground/60 break-words">
               Auto-detect uses your browser's timezone: <code
                 class="rounded bg-muted px-1 py-0.5 text-[10px]"
                 >{Intl.DateTimeFormat().resolvedOptions().timeZone}</code


### PR DESCRIPTION
This PR addresses responsive UX issues identified on mobile screens (iPhone 12 Pro viewport). 

Changes include:
1.  **Landing Page (`web/src/routes/(public)/landing/+page.svelte`):**
    *   Reduced padding on "Get Started" and "Read the Docs" buttons for mobile screens (`px-6 py-3`) while maintaining larger sizes on desktop (`md:px-12 md:py-5`).
    *   Added `overflow-x-auto` to the `CodeTyper` container to handle long lines of code without breaking the page layout.

2.  **Settings General (`web/src/routes/settings/general/+page.svelte`):**
    *   Added `max-w-full text-ellipsis` to native `<select>` elements (Chat Model, Coding CLI, Timezone) to prevent them from overflowing their containers on small screens.
    *   Added `break-words` to helper text to ensure long strings (like paths or format descriptions) wrap correctly.

Verification:
- Validated changes using a Playwright script (`verify_mobile.py`) across core routes.
- Confirmed no new type errors introduced (pre-existing errors noted in API routes).

---
*PR created automatically by Jules for task [2446845345232789699](https://jules.google.com/task/2446845345232789699) started by @hughlv*