### PR TITLE
Fix mobile responsive UX issues on Landing and Observability pages

### DIFF
--- a/web/src/routes/(public)/landing/+page.svelte
+++ b/web/src/routes/(public)/landing/+page.svelte
@@ -259,7 +259,7 @@
       </div>
 
       <h1
-        class="hero-title pb-4 text-6xl font-black leading-[1.05] tracking-tighter sm:text-7xl md:text-8xl lg:text-9xl"
+        class="hero-title pb-4 text-4xl font-black leading-[1.05] tracking-tighter sm:text-7xl md:text-8xl lg:text-9xl"
       >
         You Imagine It.<br class="hidden sm:block" />
         <span
@@ -428,7 +428,7 @@
         </div>
 
         <div class="relative rounded-xl border border-border/50 bg-card/50 backdrop-blur-sm p-2 shadow-2xl">
-           <div class="rounded-lg bg-[#0d1117] p-4 font-mono text-sm shadow-inner min-h-[300px]">
+           <div class="rounded-lg bg-[#0d1117] p-4 font-mono text-sm shadow-inner min-h-[300px] overflow-x-auto">
              <div class="flex gap-1.5 mb-4">
                <div class="size-3 rounded-full bg-red-500/80"></div>
                <div class="size-3 rounded-full bg-yellow-500/80"></div>

--- a/web/src/routes/(viberboard)/observability/+page.svelte
+++ b/web/src/routes/(viberboard)/observability/+page.svelte
@@ -201,7 +201,7 @@
 <div class="flex h-full flex-col">
   <!-- Header -->
   <div class="border-b border-border px-4 py-4 sm:px-6 lg:px-8">
-    <div class="flex items-center justify-between mb-4">
+    <div class="flex flex-col gap-4 mb-4 sm:flex-row sm:items-center sm:justify-between">
       <div class="flex items-center gap-3">
         <Logs class="size-5 text-muted-foreground" />
         <div>


### PR DESCRIPTION
This PR addresses responsive design issues identified on mobile viewports (specifically tested on iPhone SE dimensions).

Changes include:
- **Landing Page**: The hero title text size was reduced from `text-6xl` to `text-4xl` on the default breakpoint to prevent excessive wrapping and overflow. The code example container now has `overflow-x-auto` to allow horizontal scrolling of long lines.
- **Observability Page**: The header layout was updated to stack elements vertically on mobile screens using `flex-col` and switch to `flex-row` on larger screens (`sm:`). This prevents buttons and filters from overlapping or being pushed out of view.

Verified using Playwright screenshots on mobile viewports.

---
*PR created automatically by Jules for task [11184939034001614004](https://jules.google.com/task/11184939034001614004) started by @hughlv*