### PR TITLE
Add Slack Channel Support and Architecture Comparison

### DIFF
--- a/ARCHITECTURE_COMPARISON.md
+++ b/ARCHITECTURE_COMPARISON.md
@@ -1,0 +1,50 @@
+# Architecture Comparison: OpenViber vs. Nanobot
+
+This document compares the architecture of **OpenViber** and **Nanobot** to evaluate their design philosophies, scalability, and "elegance".
+
+## Executive Summary
+
+-   **OpenViber**: Designed as a **scalable, enterprise-grade platform**. It employs a micro-kernel architecture with clear separation between Daemon, Gateway, Worker, and UI. It leverages **TypeScript** for type safety and **Svelte** for a reactive, modern frontend. Ideally suited for complex, multi-agent workflows and enterprise deployments.
+-   **Nanobot**: Designed as an **ultra-lightweight, minimalistic assistant**. It is a monolithic Python application (~4k lines) optimized for simplicity and ease of hacking. Ideally suited for personal use, rapid prototyping, and users who prefer Python scripts over full-stack applications.
+
+## Detailed Comparison
+
+### 1. Architecture & Scalability
+
+| Feature | OpenViber | Nanobot | Verdict |
+| :--- | :--- | :--- | :--- |
+| **Structure** | **Micro-kernel / Services**: Separates `daemon` (lifecycle), `gateway` (API/Events), `worker` (Agent Logic), and `web` (UI). | **Monolithic**: Single Python process handling loop, context, memory, and I/O. | **OpenViber** is more scalable and maintainable for large systems. |
+| **Agent Model** | **Config-Driven**: Agents are defined by JSON/YAML config. No code required to create new agents. Supports **Swarms** and **Parallel Execution**. | **Script-Driven**: Agents are Python objects. Easy to subclass but less declarative. | **OpenViber**'s declarative approach is more elegant for management. |
+| **UI** | **Viber Board (Svelte)**: A full-featured, reactive web interface for monitoring and interaction. | **CLI / Chat**: Primarily interacts via terminal or chat apps. | **OpenViber** offers a superior user experience. |
+| **Networking** | **Gateway Pattern**: Centralized gateway handles REST, WebSocket, and SSE. Supports secure webhook verification. | **Direct Integration**: Direct API calls and socket connections within the agent loop. | **OpenViber** provides better security and separation of concerns. |
+
+### 2. Tech Stack & Coding Taste
+
+| Feature | OpenViber | Nanobot | Verdict |
+| :--- | :--- | :--- | :--- |
+| **Language** | **TypeScript**: Strict typing, interfaces, and compile-time checks. Prevents entire classes of runtime errors. | **Python**: Dynamic typing. Great for AI/ML libraries but can be fragile in large codebases without strict discipline. | **OpenViber** wins on robustness and "enterprise readiness". |
+| **Frontend** | **Svelte 5 (Runes)**: Cutting-edge reactive UI framework. Elegant state management. | **N/A**: No dedicated frontend (mostly CLI/Chat). | **OpenViber** provides a modern web interface. |
+| **Extensibility**| **Registry Pattern**: Plugins (Channels, Tools) are registered via standardized interfaces. | **Module Imports**: Extensions are Python modules imported directly. | **OpenViber**'s registry pattern is more decoupled. |
+
+### 3. Feature Parity & Improvements
+
+While OpenViber has a superior architecture for scale, **Nanobot** excels in out-of-the-box connectivity.
+
+| Feature | OpenViber | Nanobot | Status |
+| :--- | :--- | :--- | :--- |
+| **LLM Support** | **AI SDK (Vercel)**: Standardized, adapter-based. | **LiteLLM / Custom**: Flexible, easy to add. | Parity (Both support major providers). |
+| **Channels** | DingTalk, WeCom, WeChat, Discord, Feishu, Telegram. | **+ Slack, Email**, WhatsApp, QQ. | **Nanobot** has broader channel support. |
+| **Deployment** | Docker, Node.js. | Docker, Python (pip/uv). | Parity. |
+
+## Conclusion & Path Forward
+
+**OpenViber** demonstrates a much more **elegant architecture** for building a robust, long-lived agent platform. Its separation of concerns, strict typing, and modern UI make it a better choice for serious development and enterprise usage.
+
+**Nanobot** is an excellent example of **minimalist coding taste**, achieving a lot with very little code. It is elegant in its simplicity but lacks the architectural rigor for complex, multi-agent systems.
+
+### Improvements for OpenViber
+
+To match Nanobot's connectivity while maintaining architectural elegance, we will proceed with the following improvements:
+
+1.  **Implement Slack Channel**: Add a native Slack integration using **Socket Mode** (matching Nanobot's capability) to the `src/channels/` module.
+2.  (Future) **Implement Email Channel**: Add IMAP/SMTP support.

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@larksuiteoapi/node-sdk": "^1.58.0",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@openrouter/ai-sdk-provider": "^2.0.2",
+    "@slack/bolt": "^4.6.0",
     "@supabase/supabase-js": "^2.49.1",
     "ai": "^6.0.0",
     "commander": "^14.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@openrouter/ai-sdk-provider':
         specifier: ^2.0.2
         version: 2.1.1(ai@6.0.86(zod@3.25.76))(zod@3.25.76)
+      '@slack/bolt':
+        specifier: ^4.6.0
+        version: 4.6.0(@types/express@5.0.6)
       '@supabase/supabase-js':
         specifier: ^2.49.1
         version: 2.95.3
@@ -936,6 +939,32 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@slack/bolt@4.6.0':
+    resolution: {integrity: sha512-xPgfUs2+OXSugz54Ky07pA890+Qydk22SYToi8uGpXeHSt1JWwFJkRyd/9Vlg5I1AdfdpGXExDpwnbuN9Q/2dQ==}
+    engines: {node: '>=18', npm: '>=8.6.0'}
+    peerDependencies:
+      '@types/express': ^5.0.0
+
+  '@slack/logger@4.0.0':
+    resolution: {integrity: sha512-Wz7QYfPAlG/DR+DfABddUZeNgoeY7d1J39OCR2jR+v7VBsB8ezulDK5szTnDDPDwLH5IWhLvXIHlCFZV7MSKgA==}
+    engines: {node: '>= 18', npm: '>= 8.6.0'}
+
+  '@slack/oauth@3.0.4':
+    resolution: {integrity: sha512-+8H0g7mbrHndEUbYCP7uYyBCbwqmm3E6Mo3nfsDvZZW74zKk1ochfH/fWSvGInYNCVvaBUbg3RZBbTp0j8yJCg==}
+    engines: {node: '>=18', npm: '>=8.6.0'}
+
+  '@slack/socket-mode@2.0.5':
+    resolution: {integrity: sha512-VaapvmrAifeFLAFaDPfGhEwwunTKsI6bQhYzxRXw7BSujZUae5sANO76WqlVsLXuhVtCVrBWPiS2snAQR2RHJQ==}
+    engines: {node: '>= 18', npm: '>= 8.6.0'}
+
+  '@slack/types@2.20.0':
+    resolution: {integrity: sha512-PVF6P6nxzDMrzPC8fSCsnwaI+kF8YfEpxf3MqXmdyjyWTYsZQURpkK7WWUWvP5QpH55pB7zyYL9Qem/xSgc5VA==}
+    engines: {node: '>= 12.13.0', npm: '>= 6.12.0'}
+
+  '@slack/web-api@7.14.1':
+    resolution: {integrity: sha512-RoygyteJeFswxDPJjUMESn9dldWVMD2xUcHHd9DenVavSfVC6FeVnSdDerOO7m8LLvw4Q132nQM4hX8JiF7dng==}
+    engines: {node: '>= 18', npm: '>= 8.6.0'}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1104,8 +1133,14 @@ packages:
   '@telegraf/types@7.1.0':
     resolution: {integrity: sha512-kGevOIbpMcIlCDeorKGpwZmdH7kHbqlk/Yj6dEpJMKEQw5lk0KVQY0OLXaCswy8GqlIVLd5625OB+rAntP9xVw==}
 
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
@@ -1119,8 +1154,20 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/express-serve-static-core@5.1.1':
+    resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
+
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
+
+  '@types/jsonwebtoken@9.0.10':
+    resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
@@ -1134,8 +1181,23 @@ packages:
   '@types/phoenix@1.6.7':
     resolution: {integrity: sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==}
 
+  '@types/qs@6.14.0':
+    resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
+
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -1601,6 +1663,12 @@ packages:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
 
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
     engines: {node: '>=18.0.0'}
@@ -1838,6 +1906,9 @@ packages:
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
+  is-electron@2.2.2:
+    resolution: {integrity: sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
@@ -1863,6 +1934,10 @@ packages:
 
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1904,6 +1979,10 @@ packages:
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+
+  jsonwebtoken@9.0.3:
+    resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
+    engines: {node: '>=12', npm: '>=6'}
 
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
@@ -2006,8 +2085,29 @@ packages:
   lodash.identity@3.0.0:
     resolution: {integrity: sha512-AupTIzdLQxJS5wIYUQlgGyk2XRTfGXA+MCghDHqZk0pzUNYvd3EESS6dkChNauNYVIutcb0dfHw1ri9Q1yPV8Q==}
 
+  lodash.includes@4.3.0:
+    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+
+  lodash.isboolean@3.0.3:
+    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
+  lodash.isinteger@4.0.4:
+    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
+
+  lodash.isnumber@3.0.3:
+    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
+  lodash.isstring@4.0.1:
+    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash.once@4.1.1:
+    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
   lodash.pickby@4.6.0:
     resolution: {integrity: sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q==}
@@ -2285,6 +2385,22 @@ packages:
   oniguruma-to-es@2.3.0:
     resolution: {integrity: sha512-bwALDxriqfKGfUufKGGepCzu9x7nJQuoRoAFp4AnwehhC2crqrDIAP/uN2qdlsAvSMpeRC3+Yzhqc7hLmle5+g==}
 
+  p-finally@1.0.0:
+    resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
+    engines: {node: '>=4'}
+
+  p-queue@6.6.2:
+    resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
+    engines: {node: '>=8'}
+
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+
+  p-timeout@3.2.0:
+    resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
+    engines: {node: '>=8'}
+
   p-timeout@4.1.0:
     resolution: {integrity: sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==}
     engines: {node: '>=10'}
@@ -2453,6 +2569,10 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   rimraf@5.0.10:
     resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
     hasBin: true
@@ -2516,6 +2636,11 @@ packages:
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
@@ -2769,6 +2894,10 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsscmp@1.0.6:
+    resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==}
+    engines: {node: '>=0.6.x'}
 
   tsup@8.5.1:
     resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
@@ -3634,6 +3763,71 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@slack/bolt@4.6.0(@types/express@5.0.6)':
+    dependencies:
+      '@slack/logger': 4.0.0
+      '@slack/oauth': 3.0.4
+      '@slack/socket-mode': 2.0.5
+      '@slack/types': 2.20.0
+      '@slack/web-api': 7.14.1
+      '@types/express': 5.0.6
+      axios: 1.13.5
+      express: 5.2.1
+      path-to-regexp: 8.3.0
+      raw-body: 3.0.2
+      tsscmp: 1.0.6
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+
+  '@slack/logger@4.0.0':
+    dependencies:
+      '@types/node': 22.19.9
+
+  '@slack/oauth@3.0.4':
+    dependencies:
+      '@slack/logger': 4.0.0
+      '@slack/web-api': 7.14.1
+      '@types/jsonwebtoken': 9.0.10
+      '@types/node': 22.19.9
+      jsonwebtoken: 9.0.3
+    transitivePeerDependencies:
+      - debug
+
+  '@slack/socket-mode@2.0.5':
+    dependencies:
+      '@slack/logger': 4.0.0
+      '@slack/web-api': 7.14.1
+      '@types/node': 22.19.9
+      '@types/ws': 8.18.1
+      eventemitter3: 5.0.4
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+
+  '@slack/types@2.20.0': {}
+
+  '@slack/web-api@7.14.1':
+    dependencies:
+      '@slack/logger': 4.0.0
+      '@slack/types': 2.20.0
+      '@types/node': 22.19.9
+      '@types/retry': 0.12.0
+      axios: 1.13.5
+      eventemitter3: 5.0.4
+      form-data: 4.0.5
+      is-electron: 2.2.2
+      is-stream: 2.0.1
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      retry: 0.13.1
+    transitivePeerDependencies:
+      - debug
+
   '@standard-schema/spec@1.1.0': {}
 
   '@supabase/auth-js@2.95.3':
@@ -3804,10 +3998,19 @@ snapshots:
 
   '@telegraf/types@7.1.0': {}
 
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 22.19.9
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 22.19.9
 
   '@types/cookie@0.6.0': {}
 
@@ -3819,9 +4022,29 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/express-serve-static-core@5.1.1':
+    dependencies:
+      '@types/node': 22.19.9
+      '@types/qs': 6.14.0
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@5.0.6':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.1
+      '@types/serve-static': 2.2.0
+
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/http-errors@2.0.5': {}
+
+  '@types/jsonwebtoken@9.0.10':
+    dependencies:
+      '@types/ms': 2.1.0
+      '@types/node': 22.19.9
 
   '@types/mdast@4.0.4':
     dependencies:
@@ -3835,7 +4058,22 @@ snapshots:
 
   '@types/phoenix@1.6.7': {}
 
+  '@types/qs@6.14.0': {}
+
+  '@types/range-parser@1.2.7': {}
+
   '@types/resolve@1.20.2': {}
+
+  '@types/retry@0.12.0': {}
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 22.19.9
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 22.19.9
 
   '@types/unist@2.0.11': {}
 
@@ -4319,6 +4557,10 @@ snapshots:
 
   event-target-shim@5.0.1: {}
 
+  eventemitter3@4.0.7: {}
+
+  eventemitter3@5.0.4: {}
+
   eventsource-parser@3.0.6: {}
 
   eventsource@3.0.7:
@@ -4616,6 +4858,8 @@ snapshots:
 
   is-decimal@2.0.1: {}
 
+  is-electron@2.2.2: {}
+
   is-fullwidth-code-point@3.0.0: {}
 
   is-hexadecimal@2.0.1: {}
@@ -4635,6 +4879,8 @@ snapshots:
   is-reference@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
+
+  is-stream@2.0.1: {}
 
   isexe@2.0.0: {}
 
@@ -4688,6 +4934,19 @@ snapshots:
   json-schema-typed@8.0.2: {}
 
   json-schema@0.4.0: {}
+
+  jsonwebtoken@9.0.3:
+    dependencies:
+      jws: 4.0.1
+      lodash.includes: 4.3.0
+      lodash.isboolean: 3.0.3
+      lodash.isinteger: 4.0.4
+      lodash.isnumber: 3.0.3
+      lodash.isplainobject: 4.0.6
+      lodash.isstring: 4.0.1
+      lodash.once: 4.1.1
+      ms: 2.1.3
+      semver: 7.7.4
 
   jwa@2.0.1:
     dependencies:
@@ -4761,7 +5020,21 @@ snapshots:
 
   lodash.identity@3.0.0: {}
 
+  lodash.includes@4.3.0: {}
+
+  lodash.isboolean@3.0.3: {}
+
+  lodash.isinteger@4.0.4: {}
+
+  lodash.isnumber@3.0.3: {}
+
+  lodash.isplainobject@4.0.6: {}
+
+  lodash.isstring@4.0.1: {}
+
   lodash.merge@4.6.2: {}
+
+  lodash.once@4.1.1: {}
 
   lodash.pickby@4.6.0: {}
 
@@ -5209,6 +5482,22 @@ snapshots:
       regex: 5.1.1
       regex-recursion: 5.1.1
 
+  p-finally@1.0.0: {}
+
+  p-queue@6.6.2:
+    dependencies:
+      eventemitter3: 4.0.7
+      p-timeout: 3.2.0
+
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
+
+  p-timeout@3.2.0:
+    dependencies:
+      p-finally: 1.0.0
+
   p-timeout@4.1.0: {}
 
   package-json-from-dist@1.0.1: {}
@@ -5386,6 +5675,8 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  retry@0.13.1: {}
+
   rimraf@5.0.10:
     dependencies:
       glob: 10.5.0
@@ -5478,6 +5769,8 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
+
+  semver@7.7.4: {}
 
   send@1.2.1:
     dependencies:
@@ -5765,6 +6058,8 @@ snapshots:
   ts-mixer@6.0.4: {}
 
   tslib@2.8.1: {}
+
+  tsscmp@1.0.6: {}
 
   tsup@8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2):
     dependencies:

--- a/src/channels/builtin.ts
+++ b/src/channels/builtin.ts
@@ -6,6 +6,7 @@ import { WebChannel } from "./web";
 import { DiscordChannel } from "./discord";
 import { FeishuChannel } from "./feishu";
 import { TelegramChannel } from "./telegram";
+import { SlackChannel } from "./slack";
 import { channelRegistry } from "./registry";
 
 /**
@@ -123,6 +124,22 @@ export function registerBuiltinChannels(): void {
         productionReadiness: "ready",
       },
       create: (config, context) => new TelegramChannel(config as any, context),
+    });
+  }
+
+  if (!channelRegistry.get("slack")) {
+    channelRegistry.register({
+      id: "slack",
+      displayName: "Slack",
+      description: "Slack integration via Socket Mode",
+      capabilities: {
+        transport: "websocket",
+        supportsInboundAttachments: false,
+        auth: "botToken + appToken",
+        controls: ["allowChannelIds", "groupPolicy"],
+        productionReadiness: "ready",
+      },
+      create: (config, context) => new SlackChannel(config as any, context),
     });
   }
 }

--- a/src/channels/channel.ts
+++ b/src/channels/channel.ts
@@ -170,6 +170,19 @@ export interface TelegramConfig extends ChannelConfig {
   allowUserIds?: string[];
 }
 
+export interface SlackConfig extends ChannelConfig {
+  /** Slack Bot User OAuth Token (xoxb-...) */
+  botToken: string;
+  /** Slack App-Level Token (xapp-...) for Socket Mode */
+  appToken: string;
+  /** Signing Secret (optional for Socket Mode, but recommended) */
+  signingSecret?: string;
+  /** Allowlist of channel IDs to listen in (empty = all) */
+  allowChannelIds?: string[];
+  /** Group chat policy: 'mention' (default) or 'open' */
+  groupPolicy?: "mention" | "open";
+}
+
 export interface WebConfig extends ChannelConfig {
   // No special config needed for web channel
 }
@@ -181,5 +194,6 @@ export interface ChannelsConfig {
   discord?: DiscordConfig;
   feishu?: FeishuConfig;
   telegram?: TelegramConfig;
+  slack?: SlackConfig;
   web?: WebConfig;
 }

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -1,0 +1,170 @@
+import { App } from "@slack/bolt";
+import {
+  Channel,
+  ChannelRuntimeContext,
+  InboundMessage,
+  AgentStreamEvent,
+  SlackConfig,
+  InterruptSignal,
+} from "./channel";
+
+export class SlackChannel implements Channel {
+  readonly id = "slack";
+  readonly type = "websocket"; // Socket Mode
+
+  private app: App | null = null;
+  private responseBuffers = new Map<string, string>(); // conversationId -> text
+  private botUserId: string | null = null;
+
+  constructor(
+    private config: SlackConfig,
+    private context: ChannelRuntimeContext,
+  ) { }
+
+  async start(): Promise<void> {
+    if (this.app) return;
+
+    console.log("[Slack] Starting Socket Mode...");
+
+    this.app = new App({
+      token: this.config.botToken,
+      appToken: this.config.appToken,
+      socketMode: true,
+      signingSecret: this.config.signingSecret, // Optional for Socket Mode but good practice
+    });
+
+    // Fetch bot user ID for mention checking
+    const authTest = await this.app.client.auth.test();
+    this.botUserId = authTest.user_id as string;
+
+    this.setupHandlers();
+
+    await this.app.start();
+    console.log("[Slack] Connected as", authTest.user);
+  }
+
+  async stop(): Promise<void> {
+    if (!this.app) return;
+    await this.app.stop();
+    this.app = null;
+    this.responseBuffers.clear();
+    console.log("[Slack] Channel stopped");
+  }
+
+  private setupHandlers() {
+    if (!this.app) return;
+
+    this.app.message(async ({ message, say }) => {
+      // Ignore subtype messages (like channel_join, etc.) unless they are file shares which we might want later
+      if (message.subtype && message.subtype !== "file_share") return;
+
+      // Ignore bot messages
+      if ((message as any).bot_id) return;
+
+      const text = (message as any).text || "";
+      const channelId = message.channel;
+      const userId = (message as any).user;
+      const channelType = (message as any).channel_type; // 'im', 'channel', 'group', 'mpim'
+
+      // Check allowChannelIds
+      if (
+        this.config.allowChannelIds &&
+        this.config.allowChannelIds.length > 0 &&
+        !this.config.allowChannelIds.includes(channelId)
+      ) {
+        return;
+      }
+
+      // Group policy check
+      const isGroup = channelType === "channel" || channelType === "group" || channelType === "mpim";
+      if (isGroup) {
+        const policy = this.config.groupPolicy || "mention";
+        if (policy === "mention") {
+          // Check if bot is mentioned
+          if (!text.includes(`<@${this.botUserId}>`)) {
+            return;
+          }
+        }
+      }
+
+      // Prepare inbound message
+      const inbound: InboundMessage = {
+        id: (message as any).ts,
+        source: "slack",
+        userId: userId,
+        conversationId: channelId,
+        content: this.stripBotMention(text),
+        metadata: {
+          channelType,
+          threadTs: (message as any).thread_ts,
+        },
+      };
+
+      await this.handleMessage(inbound);
+    });
+  }
+
+  private stripBotMention(text: string): string {
+    if (!this.botUserId) return text;
+    const regex = new RegExp(`<@${this.botUserId}>`, "g");
+    return text.replace(regex, "").trim();
+  }
+
+  async handleMessage(message: InboundMessage): Promise<void> {
+    // Clear buffer for new turn
+    this.responseBuffers.delete(message.conversationId);
+    await this.context.routeMessage(message);
+  }
+
+  async handleInterrupt(signal: InterruptSignal): Promise<void> {
+    await this.context.handleInterrupt(signal);
+  }
+
+  async stream(conversationId: string, event: AgentStreamEvent): Promise<void> {
+    const channelId = conversationId;
+
+    try {
+      if (event.type === "text-delta") {
+        const current = this.responseBuffers.get(conversationId) || "";
+        this.responseBuffers.set(conversationId, current + event.content);
+        return;
+      }
+
+      if (event.type === "done") {
+        const text = this.responseBuffers.get(conversationId);
+        if (text) {
+          await this.sendSlackMessage(channelId, text);
+          this.responseBuffers.delete(conversationId);
+        }
+        return;
+      }
+
+      if (event.type === "error") {
+        if (this.app) {
+          await this.app.client.chat.postMessage({
+            channel: channelId,
+            text: `❌ Error: ${event.error}`,
+          });
+        }
+        this.responseBuffers.delete(conversationId);
+      }
+    } catch (error) {
+      console.error(`[Slack] Error streaming to ${channelId}:`, error);
+    }
+  }
+
+  private async sendSlackMessage(
+    channelId: string,
+    text: string,
+  ): Promise<void> {
+    if (!this.app) return;
+    try {
+        await this.app.client.chat.postMessage({
+            channel: channelId,
+            text: text,
+        });
+    } catch (err) {
+        console.error(`[Slack] Failed to send message to ${channelId}`, err);
+    }
+  }
+}


### PR DESCRIPTION
This PR adds support for Slack integration using Socket Mode via @slack/bolt, matching Nanobot's connectivity capabilities. It also includes an ARCHITECTURE_COMPARISON.md document detailing the architectural differences between OpenViber and Nanobot.

---
*PR created automatically by Jules for task [5012528751637938222](https://jules.google.com/task/5012528751637938222) started by @hughlv*