### PR TITLE
Update documentation for CLI commands and Agent Decides mode

### DIFF
--- a/docs/concepts/jobs.md
+++ b/docs/concepts/jobs.md
@@ -300,8 +300,7 @@ Hot-reloading of job files is planned but not yet implemented.
 
 ## Next Steps
 
-- [Skills](/docs/concepts/skills) — Domain knowledge for job tasks
-- [Tools](/docs/concepts/tools) — Actions available to jobs
+- [Skills & Tools](/docs/concepts/skills) — Domain knowledge and actions for job tasks
 - [Viber](/docs/concepts/viber) — Task configuration and working modes
 - [Config Schema](/docs/reference/config-schema) — Full YAML schema reference
 - [Task Lifecycle](/docs/design/task-lifecycle) — How tasks (including job-triggered tasks) flow through the system

--- a/docs/concepts/skills.md
+++ b/docs/concepts/skills.md
@@ -186,9 +186,11 @@ Click on a skill with a setup warning to see:
 
 ```bash
 # Check health via CLI
-openviber skill health github
+openviber status
 
-# Output:
+# Output (excerpt):
+# Skills
+# ────────────────────────────────────
 # github: NOT_AVAILABLE
 #   ✗ gh-cli: Not found in PATH
 #     Hint: brew install gh
@@ -204,13 +206,13 @@ The **Skill Hub** is a marketplace for discovering skills from external sources:
 
 ```bash
 # Auto-detect source
-openviber skill add github
+openviber skill import github
 
 # From npm
-openviber skill add npm:@openviber-skills/web-search
+openviber skill import npm:@openviber-skills/web-search
 
 # From GitHub
-openviber skill add dustland/viber-skills/github
+openviber skill import dustland/viber-skills/github
 ```
 
 **Sources:** OpenClaw, npm, GitHub, Hugging Face, Smithery, Composio, Glama

--- a/docs/concepts/tasks.md
+++ b/docs/concepts/tasks.md
@@ -137,7 +137,7 @@ budget:
 | Mode | Description | When to Use |
 |------|-------------|-------------|
 | **Always Ask** | Task asks before each execution action | Building trust, learning |
-| **Task Decides** | Active execution within policy boundaries | Daily work, established workflows |
+| **Agent Decides** | Active execution within policy boundaries | Daily work, established workflows |
 | **Always Execute** | High autonomy; intervene by exception | Overnight runs, trusted tasks |
 
 The mode controls how much autonomy the task has. Start with "Always Ask" and graduate as you build confidence.

--- a/docs/concepts/viber.md
+++ b/docs/concepts/viber.md
@@ -105,10 +105,10 @@ You can manage built-in and custom intent templates in **Settings → Intents**:
 | Mode               | When to Use                                                    |
 | ------------------ | -------------------------------------------------------------- |
 | **Always Ask**     | Building trust — task asks before each action                  |
-| **Viber Decides**  | Daily work — task acts within policy, escalates risky actions  |
+| **Agent Decides**  | Daily work — task acts within policy, escalates risky actions  |
 | **Always Execute** | Overnight runs — maximum autonomy, intervene by exception      |
 
-Start with "Always Ask" and graduate to "Task Decides" as you build confidence.
+Start with "Always Ask" and graduate to "Agent Decides" as you build confidence.
 
 ## You Stay in Control
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -15,7 +15,10 @@ The fastest way to get started is using `npx`:
 # 1. Set your API key (OpenRouter recommended)
 export OPENROUTER_API_KEY="your_api_key_here"
 
-# 2. Start OpenViber (Standalone)
+# 2. Initialize configuration
+npx openviber onboard
+
+# 3. Start OpenViber (Standalone)
 npx openviber start
 ```
 
@@ -62,6 +65,5 @@ Open [http://localhost:6006](http://localhost:6006) to see the Viber Board.
 
 - [Introduction](/docs/introduction) — What OpenViber is and how it works
 - [Viber](/docs/concepts/viber) — The Viber Runtime & Tasks
-- [Tools](/docs/concepts/tools) — Available actions
-- [Skills](/docs/concepts/skills) — Add domain knowledge
+- [Skills & Tools](/docs/concepts/skills) — Add domain knowledge and available actions
 - [Jobs](/docs/concepts/jobs) — Set up scheduled tasks

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -48,7 +48,7 @@ openviber chat
 
 ### 3. Enterprise Channels
 
-Connect to DingTalk or WeCom for team collaboration:
+Connect to DingTalk, WeCom, Slack, Discord, Feishu, or Telegram for team collaboration:
 
 ```bash
 # Start the enterprise channel server
@@ -74,7 +74,7 @@ OpenViber supports three levels of autonomy:
 | Mode | Behavior |
 |------|----------|
 | **Always Ask** | Task asks before each action — you approve everything |
-| **Task Decides** | Task acts within policy, escalates risky actions |
+| **Agent Decides** | Task acts within policy, escalates risky actions |
 | **Always Execute** | Maximum autonomy, intervene by exception |
 
 Start with "Always Ask" and gradually increase autonomy as you build trust.
@@ -84,5 +84,4 @@ Start with "Always Ask" and gradually increase autonomy as you build trust.
 1. **[Quick Start](/docs/getting-started/quick-start)** — Run your first task in minutes
 2. **[Viber Runtime](/docs/concepts/viber)** — Configure task behavior on your machine
 3. **[Jobs](/docs/concepts/jobs)** — Set up scheduled tasks
-4. **[Tools](/docs/concepts/tools)** — Available actions
-5. **[Skills](/docs/concepts/skills)** — Add domain knowledge
+4. **[Skills & Tools](/docs/concepts/skills)** — Add domain knowledge and available actions

--- a/docs/reference/config-schema.md
+++ b/docs/reference/config-schema.md
@@ -156,7 +156,7 @@ budget:
   mode: "hard"
 
 # Working mode default
-mode: "viber_decides"            # always_ask | viber_decides | always_execute
+mode: "agent_decides"            # always_ask | agent_decides | always_execute
 
 # Spaces this task works on
 spaces:
@@ -517,7 +517,7 @@ skills:
   - cursor-agent
   - codex-cli
 
-mode: "viber_decides"
+mode: "agent_decides"
 
 spaces:
   - ~/openviber_spaces/my-project
@@ -551,7 +551,7 @@ interface TaskConfig {
   require_approval?: string[];
   skills?: string[];
   budget?: TaskBudgetConfig;
-  mode?: "always_ask" | "viber_decides" | "always_execute";
+  mode?: "always_ask" | "agent_decides" | "always_execute";
   spaces?: string[];
   retry?: RetryConfig;
   fallback_model?: string;

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -106,7 +106,7 @@ Additional information attached to messages, Spaces, or artifacts. Used for trac
 The operational mode for task interactions:
 
 - **Always Ask**: Task asks before each action
-- **Task Decides** (or Viber Decides): Task acts within policy boundaries
+- **Agent Decides**: Task acts within policy boundaries
 - **Always Execute**: Maximum autonomy, minimal interruption
 
 ## P


### PR DESCRIPTION
This PR updates the documentation to align with the current state of the codebase and CLI commands.

Changes:
- **CLI Commands**: Updated `skill add` to `skill import` and `skill health` to `status` in `docs/concepts/skills.md`.
- **Quick Start**: Added the mandatory `npx openviber onboard` step to `docs/getting-started/quick-start.md`.
- **Terminology**: Unified the autonomous mode terminology to "Agent Decides" across `docs/concepts/viber.md`, `docs/concepts/tasks.md`, `docs/introduction.md`, `docs/reference/glossary.md`, and `docs/reference/config-schema.md`.
- **Channels**: Updated the list of supported channels in `docs/introduction.md` to include Slack, Discord, Feishu, and Telegram.
- **Links**: Fixed broken links to `tools.md` by pointing them to `skills.md` (Skills & Tools) in `docs/introduction.md` and `docs/concepts/jobs.md`.
- **Config Schema**: Updated the configuration schema reference to use `agent_decides`.

Verified that `pnpm build:web` passes successfully.

---
*PR created automatically by Jules for task [1637745193237358629](https://jules.google.com/task/1637745193237358629) started by @hughlv*