### PR TITLE
docs: update outdated CLI commands and terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ npx openviber start
 If you prefer to install it globally:
 ```bash
 npm install -g openviber
-viber start
+openviber start
 ```
 
 ---
@@ -86,7 +86,7 @@ Use OpenViber from any terminal. It integrates deeply with tmux for streaming ou
 
 ```bash
 # Start an interactive chat
-viber chat
+npx openviber chat
 ```
 
 ### 🌐 Viber Board (Web UI)
@@ -97,8 +97,8 @@ Deploy your tasks to where your team works. Support for **DingTalk** and **WeCom
 
 ```bash
 # Start the enterprise channel server
-# Note: Defaults to port 6009. If running alongside 'viber start' (which also uses 6009), use a different port:
-viber channels --port 6010
+# Note: Defaults to port 6009. If running alongside 'openviber start' (which also uses 6009), use a different port:
+npx openviber channels --port 6010
 ```
 
 ---

--- a/docs/concepts/skills.md
+++ b/docs/concepts/skills.md
@@ -186,14 +186,16 @@ Click on a skill with a setup warning to see:
 
 ```bash
 # Check health via CLI
-openviber skill health github
+npx openviber status
 
 # Output:
-# github: NOT_AVAILABLE
-#   ✗ gh-cli: Not found in PATH
-#     Hint: brew install gh
-#   ✗ gh-auth: Not authenticated
-#     Hint: gh auth login
+# ...
+# Skills:
+#   github: NOT_AVAILABLE
+#     ✗ gh-cli: Not found in PATH
+#       Hint: brew install gh
+#     ✗ gh-auth: Not authenticated
+#       Hint: gh auth login
 ```
 
 ---
@@ -204,13 +206,13 @@ The **Skill Hub** is a marketplace for discovering skills from external sources:
 
 ```bash
 # Auto-detect source
-openviber skill add github
+npx openviber skill import github
 
 # From npm
-openviber skill add npm:@openviber-skills/web-search
+npx openviber skill import npm:@openviber-skills/web-search
 
 # From GitHub
-openviber skill add dustland/viber-skills/github
+npx openviber skill import dustland/viber-skills/github
 ```
 
 **Sources:** OpenClaw, npm, GitHub, Hugging Face, Smithery, Composio, Glama

--- a/docs/concepts/tasks.md
+++ b/docs/concepts/tasks.md
@@ -137,7 +137,7 @@ budget:
 | Mode | Description | When to Use |
 |------|-------------|-------------|
 | **Always Ask** | Task asks before each execution action | Building trust, learning |
-| **Task Decides** | Active execution within policy boundaries | Daily work, established workflows |
+| **Agent Decides** | Active execution within policy boundaries | Daily work, established workflows |
 | **Always Execute** | High autonomy; intervene by exception | Overnight runs, trusted tasks |
 
 The mode controls how much autonomy the task has. Start with "Always Ask" and graduate as you build confidence.
@@ -214,13 +214,13 @@ To run an ad-hoc task using a specific agent configuration:
 ```bash
 # Run a task using the "dev-task" configuration
 # (Loads config from ~/.openviber/vibers/dev-task.yaml)
-viber run --agent dev-task "Refactor the authentication module"
+npx openviber run --agent dev-task "Refactor the authentication module"
 ```
 
 To run a task using the default agent:
 
 ```bash
-viber run "Check my GitHub notifications"
+npx openviber run "Check my GitHub notifications"
 ```
 
 ---

--- a/docs/concepts/viber.md
+++ b/docs/concepts/viber.md
@@ -105,10 +105,10 @@ You can manage built-in and custom intent templates in **Settings → Intents**:
 | Mode               | When to Use                                                    |
 | ------------------ | -------------------------------------------------------------- |
 | **Always Ask**     | Building trust — task asks before each action                  |
-| **Viber Decides**  | Daily work — task acts within policy, escalates risky actions  |
+| **Agent Decides**  | Daily work — task acts within policy, escalates risky actions  |
 | **Always Execute** | Overnight runs — maximum autonomy, intervene by exception      |
 
-Start with "Always Ask" and graduate to "Task Decides" as you build confidence.
+Start with "Always Ask" and graduate to "Agent Decides" as you build confidence.
 
 ## You Stay in Control
 

--- a/docs/reference/config-schema.md
+++ b/docs/reference/config-schema.md
@@ -156,7 +156,7 @@ budget:
   mode: "hard"
 
 # Working mode default
-mode: "viber_decides"            # always_ask | viber_decides | always_execute
+mode: "agent_decides"            # always_ask | agent_decides | always_execute
 
 # Spaces this task works on
 spaces:
@@ -517,7 +517,7 @@ skills:
   - cursor-agent
   - codex-cli
 
-mode: "viber_decides"
+mode: "agent_decides"
 
 spaces:
   - ~/openviber_spaces/my-project
@@ -551,7 +551,7 @@ interface TaskConfig {
   require_approval?: string[];
   skills?: string[];
   budget?: TaskBudgetConfig;
-  mode?: "always_ask" | "viber_decides" | "always_execute";
+  mode?: "always_ask" | "agent_decides" | "always_execute";
   spaces?: string[];
   retry?: RetryConfig;
   fallback_model?: string;


### PR DESCRIPTION
This PR updates the documentation to align with the current state of the CLI and codebase terminology.

Key changes:
- **Terminology:** Replaced "Viber Decides" and "Task Decides" with "Agent Decides" in `docs/concepts/viber.md`, `docs/concepts/tasks.md`, and `docs/reference/config-schema.md`.
- **CLI Commands:**
    - Updated `openviber skill add` to `openviber skill import` in `docs/concepts/skills.md`.
    - Updated `openviber skill health` to `openviber status` in `docs/concepts/skills.md`.
- **Usage Standards:**
    - Replaced `viber run` and `viber start` with `npx openviber run` and `npx openviber start` in `README.md` and `docs/concepts/tasks.md` to promote consistent usage.
- **Config Schema:** Updated the `mode` field in YAML examples and TypeScript definitions to use `agent_decides`.

---
*PR created automatically by Jules for task [11939545661086002148](https://jules.google.com/task/11939545661086002148) started by @hughlv*