### PR TITLE
fix(ux): improve mobile responsiveness for landing, settings, and tasks pages

### DIFF
--- a/web/src/routes/(public)/landing/+page.svelte
+++ b/web/src/routes/(public)/landing/+page.svelte
@@ -259,7 +259,7 @@
       </div>
 
       <h1
-        class="hero-title pb-4 text-6xl font-black leading-[1.05] tracking-tighter sm:text-7xl md:text-8xl lg:text-9xl"
+        class="hero-title pb-4 text-5xl font-black leading-[1.05] tracking-tighter sm:text-7xl md:text-8xl lg:text-9xl"
       >
         You Imagine It.<br class="hidden sm:block" />
         <span
@@ -308,7 +308,7 @@
         {#if data.user}
           <a
             href="/"
-            class="cta-primary group inline-flex items-center gap-3 rounded-full bg-primary px-12 py-5 text-lg font-bold text-primary-foreground shadow-[0_0_40px_hsl(var(--primary)/0.4)] transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_0_60px_hsl(var(--primary)/0.5)]"
+            class="cta-primary group inline-flex items-center gap-3 rounded-full bg-primary px-8 py-4 text-base md:px-12 md:py-5 md:text-lg font-bold text-primary-foreground shadow-[0_0_40px_hsl(var(--primary)/0.4)] transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_0_60px_hsl(var(--primary)/0.5)]"
           >
             Go to Viberboard
             <ArrowRight
@@ -318,7 +318,7 @@
         {:else if data.supabaseAuthEnabled}
           <a
             href={githubAuthUrl}
-            class="cta-primary group inline-flex items-center gap-3 rounded-full bg-primary px-12 py-5 text-lg font-bold text-primary-foreground shadow-[0_0_40px_hsl(var(--primary)/0.4)] transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_0_60px_hsl(var(--primary)/0.5)]"
+            class="cta-primary group inline-flex items-center gap-3 rounded-full bg-primary px-8 py-4 text-base md:px-12 md:py-5 md:text-lg font-bold text-primary-foreground shadow-[0_0_40px_hsl(var(--primary)/0.4)] transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_0_60px_hsl(var(--primary)/0.5)]"
           >
             <svg
               class="size-5"
@@ -428,7 +428,7 @@
         </div>
 
         <div class="relative rounded-xl border border-border/50 bg-card/50 backdrop-blur-sm p-2 shadow-2xl">
-           <div class="rounded-lg bg-[#0d1117] p-4 font-mono text-sm shadow-inner min-h-[300px]">
+           <div class="rounded-lg bg-[#0d1117] p-4 font-mono text-sm shadow-inner min-h-[300px] overflow-x-auto">
              <div class="flex gap-1.5 mb-4">
                <div class="size-3 rounded-full bg-red-500/80"></div>
                <div class="size-3 rounded-full bg-yellow-500/80"></div>

--- a/web/src/routes/(viberboard)/tasks/+page.svelte
+++ b/web/src/routes/(viberboard)/tasks/+page.svelte
@@ -138,7 +138,7 @@
         {/if}
       </p>
     </div>
-    <div class="flex items-center gap-2">
+    <div class="flex items-center gap-2 w-full sm:w-auto justify-between sm:justify-normal">
       <Button
         variant={showArchived ? "secondary" : "outline"}
         size="sm"

--- a/web/src/routes/settings/general/+page.svelte
+++ b/web/src/routes/settings/general/+page.svelte
@@ -497,7 +497,7 @@
             <select
               id="chat-model"
               bind:value={editChatModel}
-              class="w-full h-9 rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 focus:ring-offset-background"
+              class="w-full h-9 rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 focus:ring-offset-background max-w-full text-ellipsis"
             >
               {#each MODEL_OPTIONS as opt (opt.id)}
                 <option value={opt.id}>{opt.label}</option>
@@ -604,7 +604,7 @@
             <select
               id="primary-coding-cli"
               bind:value={editPrimaryCodingCli}
-              class="w-full h-9 rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 focus:ring-offset-background"
+              class="w-full h-9 rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 focus:ring-offset-background max-w-full text-ellipsis"
             >
               <option value="">Let agent choose</option>
               {#each codingCliOptions as opt (opt.id)}
@@ -636,7 +636,7 @@
             <select
               id="timezone"
               bind:value={editTimezone}
-              class="w-full h-9 rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 focus:ring-offset-background"
+              class="w-full h-9 rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 focus:ring-offset-background max-w-full text-ellipsis"
             >
               {#each POPULAR_TIMEZONES as tz (tz.id)}
                 <option value={tz.id}>{tz.label}</option>


### PR DESCRIPTION
This PR addresses several responsive UX issues identified on mobile screens (iPhone 12 viewport).

Changes:
1.  **Landing Page:**
    *   Reduced the main hero title from `text-6xl` to `text-5xl` on mobile devices to prevent text wrapping and overflow issues.
    *   Reduced padding on primary CTA buttons (`px-8 py-4` mobile, `md:px-12 md:py-5` desktop) to ensure they fit side-by-side or stack gracefully.
    *   Added `overflow-x-auto` to the `CodeTyper` container to allow horizontal scrolling of long code lines on small screens.

2.  **Settings Page:**
    *   Added `max-w-full` and `text-ellipsis` to native `<select>` elements (Model, Timezone, CLI) to prevent them from breaking the container width on mobile.

3.  **Tasks Page:**
    *   Refactored the header action buttons container to use `w-full sm:w-auto justify-between` for better spacing and alignment on mobile devices.

These changes were verified using Playwright scripts simulating an iPhone 12 Pro viewport.

---
*PR created automatically by Jules for task [17895718756955123297](https://jules.google.com/task/17895718756955123297) started by @hughlv*