### PR TITLE
docs: Update obsolete viber CLI commands to npx openviber

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ npx openviber start
 If you prefer to install it globally:
 ```bash
 npm install -g openviber
-viber start
+openviber start
 ```
 
 ---
@@ -86,7 +86,7 @@ Use OpenViber from any terminal. It integrates deeply with tmux for streaming ou
 
 ```bash
 # Start an interactive chat
-viber chat
+npx openviber chat
 ```
 
 ### 🌐 Viber Board (Web UI)
@@ -97,8 +97,8 @@ Deploy your tasks to where your team works. Support for **DingTalk** and **WeCom
 
 ```bash
 # Start the enterprise channel server
-# Note: Defaults to port 6009. If running alongside 'viber start' (which also uses 6009), use a different port:
-viber channels --port 6010
+# Note: Defaults to port 6009. If running alongside 'openviber start' (which also uses 6009), use a different port:
+openviber channels --port 6010
 ```
 
 ---

--- a/README_CN.md
+++ b/README_CN.md
@@ -43,7 +43,7 @@ npx openviber start
 如果您希望全局安装：
 ```bash
 npm install -g openviber
-viber start
+openviber start
 ```
 
 ---
@@ -87,7 +87,7 @@ OpenViber 提供多种与 Viber 交互的方式，专为开发者和团队设计
 
 ```bash
 # 启动交互式对话
-viber chat
+npx openviber chat
 ```
 
 ### 🌐 Viber Board (Web UI)
@@ -98,7 +98,7 @@ viber chat
 
 ```bash
 # 启动企业网关
-viber channels
+openviber channels
 ```
 
 ---

--- a/docs/concepts/jobs.md
+++ b/docs/concepts/jobs.md
@@ -293,7 +293,7 @@ The scheduler uses [Croner](https://github.com/hexagon/croner) for cron parsing 
 ### Reloading
 
 Changes to job files require either:
-- Restarting OpenViber (`openviber start`)
+- Restarting OpenViber (`npx openviber start`)
 - A gateway-triggered reload (when a job is pushed from the Viber Board)
 
 Hot-reloading of job files is planned but not yet implemented.

--- a/docs/concepts/skills.md
+++ b/docs/concepts/skills.md
@@ -186,7 +186,7 @@ Click on a skill with a setup warning to see:
 
 ```bash
 # Check health via CLI
-openviber skill health github
+npx openviber status github
 
 # Output:
 # github: NOT_AVAILABLE
@@ -204,13 +204,13 @@ The **Skill Hub** is a marketplace for discovering skills from external sources:
 
 ```bash
 # Auto-detect source
-openviber skill add github
+npx openviber skill import github
 
 # From npm
-openviber skill add npm:@openviber-skills/web-search
+npx openviber skill import npm:@openviber-skills/web-search
 
 # From GitHub
-openviber skill add dustland/viber-skills/github
+npx openviber skill import dustland/viber-skills/github
 ```
 
 **Sources:** OpenClaw, npm, GitHub, Hugging Face, Smithery, Composio, Glama

--- a/docs/concepts/tasks.md
+++ b/docs/concepts/tasks.md
@@ -214,13 +214,13 @@ To run an ad-hoc task using a specific agent configuration:
 ```bash
 # Run a task using the "dev-task" configuration
 # (Loads config from ~/.openviber/vibers/dev-task.yaml)
-viber run --agent dev-task "Refactor the authentication module"
+npx openviber run --agent dev-task "Refactor the authentication module"
 ```
 
 To run a task using the default agent:
 
 ```bash
-viber run "Check my GitHub notifications"
+npx openviber run "Check my GitHub notifications"
 ```
 
 ---

--- a/docs/design/communication.md
+++ b/docs/design/communication.md
@@ -14,7 +14,7 @@ Communication in OpenViber connects operators to their vibers. The primary inter
 | Surface | Transport | Use Case |
 |---------|-----------|----------|
 | **Viber Board** (web UI) | HTTP + SSE via AI SDK | Primary: chat, observe terminals, manage vibers |
-| **CLI** | Direct daemon call | Quick tasks: `openviber run "build the landing page"` |
+| **CLI** | Direct daemon call | Quick tasks: `npx openviber run "build the landing page"` |
 | **Enterprise channels** | Channel APIs (future) | DingTalk, WeCom, Slack — async task management |
 
 ---

--- a/docs/design/environments-and-tasks.md
+++ b/docs/design/environments-and-tasks.md
@@ -235,7 +235,7 @@ Practical rule:
 
 ### v1 (recommended)
 
-- Keep current `openviber onboard --token ...` bootstrap.
+- Keep current `npx openviber onboard --token ...` bootstrap.
 - Add remote `environment:prepare` so users never run repo/setup commands manually again.
 
 ### v2 (optional)

--- a/docs/design/openclaw-feature-comparison.md
+++ b/docs/design/openclaw-feature-comparison.md
@@ -22,7 +22,7 @@ This document compares OpenViber's feature set and **operator experience** again
 | **Stars** | ~100 | ~175,000 |
 | **Deployment** | Local-first, `npx openviber start` | Local-first, `openclaw onboard --install-daemon` |
 
-Terminology mapping: OpenViber's **Gateway** (`viber gateway`) is the central coordinator (OpenClaw's "gateway control plane"), and OpenViber's **daemon** is the Viber runtime. The **Channels** server (`viber channels`) runs enterprise channel webhooks (DingTalk, WeCom, etc.) and is a separate component.
+Terminology mapping: OpenViber's **Gateway** (`npx openviber gateway`) is the central coordinator (OpenClaw's "gateway control plane"), and OpenViber's **daemon** is the Viber runtime. The **Channels** server (`npx openviber channels`) runs enterprise channel webhooks (DingTalk, WeCom, etc.) and is a separate component.
 
 ---
 
@@ -285,7 +285,7 @@ The following gaps represent the most impactful features that OpenViber should c
 
 6. **Media Pipeline** — Image, audio, and video understanding is table stakes for a modern AI assistant.
 
-7. **Health Check / Doctor Command** — Self-diagnostic tooling (`viber doctor`) for troubleshooting configuration and connectivity issues.
+7. **Health Check / Doctor Command** — Self-diagnostic tooling (`npx openviber status`) for troubleshooting configuration and connectivity issues.
 
 8. **OS-Level Daemon Management** — Install as launchd/systemd service for always-on operation without terminal.
 

--- a/docs/design/protocol.md
+++ b/docs/design/protocol.md
@@ -12,8 +12,8 @@ OpenViber's runtime has three components that communicate:
 3. **Web App (Viber Board)** — SvelteKit frontend that operators use to interact with tasks.
 
 Terminology note: in this doc, "daemon" refers to the Viber runtime process. "Gateway" is the
-central coordinator (started with `viber gateway`). This is distinct from the **Channels** server
-(`viber channels`, enterprise channel webhooks) and the **Skill Hub** (`src/skills/hub/`).
+central coordinator (started with `npx openviber gateway`). This is distinct from the **Channels** server
+(`npx openviber channels`, enterprise channel webhooks) and the **Skill Hub** (`src/skills/hub/`).
 
 The protocol is intentionally simple. The AI SDK handles the complex parts (streaming, tool calls, message formatting). OpenViber's protocol is just the plumbing that connects them.
 

--- a/docs/design/viber.md
+++ b/docs/design/viber.md
@@ -242,8 +242,8 @@ This single command:
 ## 9. Gateway (Central Coordinator)
 
 After onboarding, the Viber communicates with the Viber Board (web app) via a WebSocket control plane.
-In this repo, that control plane is implemented by the **Gateway** (`viber gateway`). This is distinct
-from the **Channels** server (`viber channels`, enterprise channel webhooks) and from the **Viber runtime**
+In this repo, that control plane is implemented by the **Gateway** (`npx openviber gateway`). This is distinct
+from the **Channels** server (`npx openviber channels`, enterprise channel webhooks) and from the **Viber runtime**
 (often called the daemon).
 
 - **Single gateway per host** — one Viber is the authority for channel connections and tasks run on that machine.

--- a/docs/guides/environment-setup.md
+++ b/docs/guides/environment-setup.md
@@ -31,11 +31,11 @@ openviber env run setup
 openviber env run maintenance
 ```
 
-Before setup/maintenance (and before `openviber run` / `openviber start` when an environment exists), OpenViber validates required vars and reports missing keys.
+Before setup/maintenance (and before `npx openviber run` / `npx openviber start` when an environment exists), OpenViber validates required vars and reports missing keys.
 
 ## 4. Runtime behavior
 
-- `openviber run --env <env-id>` and `openviber start --env <env-id>` select an environment id.
+- `npx openviber run --env <env-id>` and `npx openviber start --env <env-id>` select an environment id.
 - Runtime env vars are injected into terminal/tmux child processes only (not by mutating global `process.env`).
 - Variables with `scope: setup_only` are available during setup/maintenance but not injected into terminal runtime.
 - Values marked `secret: true` are redacted from terminal stream output.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -40,10 +40,10 @@ Run one-off tasks or interact via terminal:
 
 ```bash
 # Start a task (on your local Viber)
-openviber run "Create a README for this project"
+npx openviber run "Create a README for this project"
 
 # Interactive terminal chat (tmux-friendly)
-openviber chat
+npx openviber chat
 ```
 
 ### 3. Enterprise Channels
@@ -52,7 +52,7 @@ Connect to DingTalk or WeCom for team collaboration:
 
 ```bash
 # Start the enterprise channel server
-openviber channels
+npx openviber channels
 ```
 
 > **Note:** Requires configuration of API keys in environment variables. See documentation for details.

--- a/docs/reference/config-schema.md
+++ b/docs/reference/config-schema.md
@@ -89,7 +89,7 @@ channels:
     proxyUrl: "${WECHAT_PROXY_URL}"
     accountId: "${WECHAT_ACCOUNT_ID}"
 
-# Channels gateway settings (webhook server for DingTalk, WeCom, etc.; started with `viber channels`)
+# Channels gateway settings (webhook server for DingTalk, WeCom, etc.; started with `npx openviber channels`)
 gateway:
   host: "0.0.0.0"
   port: 6009
@@ -466,7 +466,7 @@ The daemon validates all configuration at startup. Common errors:
 ### Validation Command
 
 ```bash
-openviber config validate
+npx openviber config validate
 ```
 
 ## 10. Example Complete Setup

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -51,7 +51,7 @@ Gateway. In docs, "daemon" and "Viber runtime" are used interchangeably.
 ### Gateway
 
 The central coordinator that routes messages between Viber runtimes (daemons) and the web app.
-Started via `viber gateway`. Vibers connect outbound to the gateway via WebSocket; the web app
+Started via `npx openviber gateway`. Vibers connect outbound to the gateway via WebSocket; the web app
 (Viber Board) talks to the gateway via REST and SSE. This is distinct from the **Channels**
 server (enterprise channel webhooks) and from the **Skill Hub** (external skill registry).
 
@@ -70,7 +70,7 @@ the Gateway (central coordinator).
 ### Channels (enterprise channel server)
 
 The HTTP server that receives webhooks from enterprise channels (DingTalk, WeCom, Discord,
-Feishu). Started via `viber channels`. Implemented by `ChannelGateway` in `src/channels/gateway.ts`.
+Feishu). Started via `npx openviber channels`. Implemented by `ChannelGateway` in `src/channels/gateway.ts`.
 Distinct from the Gateway (central coordinator for Vibers).
 
 ## J

--- a/docs/reference/viber-node-self-contained-review.md
+++ b/docs/reference/viber-node-self-contained-review.md
@@ -16,11 +16,11 @@ This revision reflects the latest terminology direction:
 
 Compared to the earlier review, there is meaningful progress around standalone onboarding and task-centric language in parts of the stack:
 
-- Onboarding now supports an explicit **standalone mode** (`openviber onboard` without token).
+- Onboarding now supports an explicit **standalone mode** (`npx openviber onboard` without token).
 - Standalone onboarding scaffolds local config and personalization files under `~/.openviber`.
 - The CLI and runtime internals increasingly use task-oriented naming even where external compatibility still uses `viber` terminology.
 
-That said, daemon runtime boot (`openviber start`) still initializes the controller path that expects a gateway WebSocket endpoint (remote or local default).
+That said, daemon runtime boot (`npx openviber start`) still initializes the controller path that expects a gateway WebSocket endpoint (remote or local default).
 
 ## Executive Summary
 
@@ -42,14 +42,14 @@ That said, daemon runtime boot (`openviber start`) still initializes the control
 
 ### 2) Standalone setup has improved materially
 
-- `openviber onboard` now supports standalone setup when no token is passed.
+- `npx openviber onboard` now supports standalone setup when no token is passed.
 - Standalone mode writes `~/.openviber/config.yaml` with `mode: "standalone"` and scaffolds local viber config + personalization files.
 
 **Assessment:** ✅ Significant operational UX improvement for local-only users.
 
 ### 3) Daemon start path is still gateway-controller oriented
 
-- `openviber start` still builds `ViberController` and uses server URL resolution logic that defaults to local gateway WebSocket (`ws://localhost:6009/ws`) when no connected config is present.
+- `npx openviber start` still builds `ViberController` and uses server URL resolution logic that defaults to local gateway WebSocket (`ws://localhost:6009/ws`) when no connected config is present.
 - Therefore, the daemon control loop remains oriented around inbound gateway messages for task submit/stop/message orchestration.
 
 **Assessment:** ⚠️ Core engine can run alone, but daemon orchestration is not yet fully gateway-independent.
@@ -73,21 +73,21 @@ That said, daemon runtime boot (`openviber start`) still initializes the control
 
 | Capability | Gateway required? | Supabase required? | Notes |
 |---|---:|---:|---|
-| Local single task (`openviber run`) | No | No | Fully local task runtime |
+| Local single task (`npx openviber run`) | No | No | Fully local task runtime |
 | Standalone onboarding | No | No | Local config scaffolding + personalization bootstrap |
-| Daemon runtime (`openviber start`) | Practically yes today (remote or local gateway WS) | No | Controller-first orchestration path |
+| Daemon runtime (`npx openviber start`) | Practically yes today (remote or local gateway WS) | No | Controller-first orchestration path |
 | Task status via gateway APIs | Yes | No (local gateway mode) | Today primarily exposed via `/api/vibers/*` compatibility routes |
 | Supabase-backed web persistence | No (for local runtime) | Yes | Optional web/data mode |
 
 ## Gaps to “fully self-contained Viber engine”
 
-1. `openviber start` has not yet fully split into a true local orchestration loop independent of gateway WS semantics.
+1. `npx openviber start` has not yet fully split into a true local orchestration loop independent of gateway WS semantics.
 2. Task ingress/control in daemon mode is still predominantly gateway-message-driven.
 3. Naming migration still spans both task-first and legacy viber vocabulary, which can obscure architecture boundaries.
 
 ## Recommendations (Updated)
 
-1. Introduce a strict **standalone runtime mode** in `openviber start` that does not attempt gateway connection by default.
+1. Introduce a strict **standalone runtime mode** in `npx openviber start` that does not attempt gateway connection by default.
 2. Provide first-class local task ingress in standalone mode (local HTTP/WS/IPC) for submit/stop/message.
 3. Continue API/event contract migration to task-first naming while maintaining explicit compatibility layers.
 4. Document runtime profiles clearly:


### PR DESCRIPTION
This PR updates documentation and guides across the repository to correctly refer to OpenViber CLI commands rather than old `viber <cmd>` prefixes.

Changes:
- Replaces generic `viber` references with `npx openviber` where applicable.
- Fixed outdated commands like `openviber skill add` to `npx openviber skill import`.
- Fixed `openviber doctor` and `openviber skill health` to `npx openviber status`.
- Fixed global tool reference instructions correctly retaining `openviber` alone.

---
*PR created automatically by Jules for task [15257171067992163869](https://jules.google.com/task/15257171067992163869) started by @hughlv*