### PR TITLE
docs: compare architecture with nanobot

### DIFF
--- a/ARCHITECTURE_COMPARISON_NANOBOT.md
+++ b/ARCHITECTURE_COMPARISON_NANOBOT.md
@@ -1,0 +1,56 @@
+# Architecture Comparison: OpenViber vs. Nanobot
+
+This document compares the architectural design and coding tastes of **OpenViber** against the [Nanobot](https://github.com/HKUDS/nanobot) project. While Nanobot aims to provide an ultra-lightweight approach (under 4,000 lines of Python), OpenViber focuses on an enterprise-ready, strongly-typed, and modular multi-agent platform.
+
+By evaluating the project structure, separation of concerns, and security paradigms, it becomes clear that OpenViber provides a significantly more elegant and scalable architecture.
+
+## 1. Core Architectural Paradigms
+
+### OpenViber: Multi-Layered, Enterprise-Grade Design
+OpenViber embraces a clean **Separation of Concerns** using a structured layered architecture (Gateway, Worker, Channels):
+- **Gateway Layer (`src/gateway/`)**: A dedicated HTTP gateway server that handles authentication, rate-limiting, idempotency, and security boundaries.
+- **Worker Layer (`src/worker/`)**: Decouples single-agent execution from multi-agent coordination. Instead of a single script, it uses an `AgentSwarm` to route tasks and a `ParallelExecutionEngine` for concurrent execution. It orchestrates roles, tasks, and plans cleanly.
+- **Channel Layer (`src/channels/`)**: Dedicated abstractions for inbound/outbound integrations (Slack, Web, Enterprise APIs).
+
+### Nanobot: Monolithic Loop Design
+Nanobot consolidates core logic into a monolithic `agent/` directory:
+- `loop.py`: A simple LLM ↔ tool execution loop.
+- Background tasks and memory are more tightly coupled.
+- Minimal structural boundaries make it difficult to scale into multi-tenant or distributed environments without rewriting core components.
+
+## 2. Abstraction and Interfaces (Coding Tastes)
+
+### Tool System
+- **OpenViber**: Employs a **Trait-based Design** (`src/worker/tool-trait.ts`). All tools implement a unified interface, strictly passing a `ToolContext` with a `SecurityPolicy` and `RuntimeAdapter`. This isolates arbitrary system access and allows swapping out the execution environment (e.g., executing tools inside Docker containers).
+- **Nanobot**: Built-in tools are simple Python functions or module calls. Security constraints are basic and often depend on simple path checking or directory appending, lacking a robust adapter pattern for executing safely in diverse environments.
+
+### Type Safety
+- **OpenViber**: Written primarily in **TypeScript**, enforcing strict contracts between system boundaries. Types like `ToolSpec`, `SecurityPolicy`, and `SwarmResult` guarantee input/output shapes, mitigating runtime anomalies typical in complex agent operations.
+- **Nanobot**: Written in **Python**. While it is clean and compact, it prioritizes minimizing lines-of-code over rigorous enterprise interface definitions and strict type compilation.
+
+## 3. Security and Coordination
+
+### Security First
+- **OpenViber**: Integrates security natively at the Gateway layer. It employs a `PairingGuard` for token exchanges, constant-time webhook secret validation, and sliding-window rate limiters. Tools strictly adhere to workspace restrictions and runtime policies enforced at the abstraction layer.
+- **Nanobot**: Relies on basic configurations like `restrictToWorkspace`, without dedicated architectural layers preventing abuse in public webhook scenarios.
+
+### Swarm & Collaboration
+- **OpenViber**: Introduces `AgentSwarm` and multi-agent coordination primitives. Complex tasks can be broken down, parallelized, and evaluated by different specialized agents dynamically. Multi-tenancy is handled via "Spaces", strictly isolating task states and memory.
+- **Nanobot**: Single-agent loop processing (`agent/loop.py`) restricts capabilities to straightforward, linear task fulfillment.
+
+## 4. Configuration and Personalization
+
+### OpenViber: The "Three-File" (or Four-File) Pattern
+OpenViber separates agent personality cleanly into:
+1. `IDENTITY.md` (Shared identity)
+2. `USER.md` (Context/preferences)
+3. `SOUL.md` (Boundaries/Personality)
+4. `MEMORY.md` (Long-term decisions)
+This clear separation prevents monolithic prompt strings and provides maintainable, role-scoped contextual windows for the AI.
+
+### Nanobot: Standard Configuration
+Relies predominantly on a central `.json` configuration file combined with simple text prompts or workspace-injected context, which becomes unwieldy when modeling highly specialized autonomous agents.
+
+## Conclusion
+
+While Nanobot optimizes for an ultra-lightweight footprint and minimal lines of code for personal use scenarios, **OpenViber is designed as a mature, multi-tenant platform.** OpenViber's use of strict TypeScript typing, interface-driven Tool traits, decoupled Gateways, and a multi-agent Swarm engine demonstrates a vastly more elegant software architecture. It ensures scalability, safety, and maintainability suitable for robust, collaborative enterprise deployments.


### PR DESCRIPTION
Added `ARCHITECTURE_COMPARISON_NANOBOT.md` to document the architectural differences between OpenViber and Nanobot. This comparison highlights OpenViber's multi-layered architecture (Gateway, Worker, Channels), trait-based Tool execution system with strict typing and security constraints, and `AgentSwarm` approach in contrast to Nanobot's minimal, script-oriented monolithic loop design.

---
*PR created automatically by Jules for task [16064261291165814249](https://jules.google.com/task/16064261291165814249) started by @hughlv*