### PR TITLE
docs: update outdated documentation and configs

### DIFF
--- a/docs/concepts/skills.md
+++ b/docs/concepts/skills.md
@@ -186,7 +186,7 @@ Click on a skill with a setup warning to see:
 
 ```bash
 # Check health via CLI
-openviber skill health github
+npx openviber status
 
 # Output:
 # github: NOT_AVAILABLE
@@ -204,13 +204,13 @@ The **Skill Hub** is a marketplace for discovering skills from external sources:
 
 ```bash
 # Auto-detect source
-openviber skill add github
+npx openviber skill import github
 
 # From npm
-openviber skill add npm:@openviber-skills/web-search
+npx openviber skill import npm:@openviber-skills/web-search
 
 # From GitHub
-openviber skill add dustland/viber-skills/github
+npx openviber skill import dustland/viber-skills/github
 ```
 
 **Sources:** OpenClaw, npm, GitHub, Hugging Face, Smithery, Composio, Glama

--- a/docs/design/openclaw-feature-comparison.md
+++ b/docs/design/openclaw-feature-comparison.md
@@ -285,7 +285,7 @@ The following gaps represent the most impactful features that OpenViber should c
 
 6. **Media Pipeline** — Image, audio, and video understanding is table stakes for a modern AI assistant.
 
-7. **Health Check / Doctor Command** — Self-diagnostic tooling (`viber doctor`) for troubleshooting configuration and connectivity issues.
+7. **Health Check / Doctor Command** — Self-diagnostic tooling (`npx openviber status`) for troubleshooting configuration and connectivity issues.
 
 8. **OS-Level Daemon Management** — Install as launchd/systemd service for always-on operation without terminal.
 

--- a/src/cli/auth.test.ts
+++ b/src/cli/auth.test.ts
@@ -12,7 +12,7 @@ import * as path from "path";
 import * as http from "http";
 
 // Mock config module so settings use a temp directory
-vi.mock("../core/config-runtime", () => ({
+vi.mock("../utils/paths", () => ({
   getViberRoot: () => "/tmp/openviber-test-auth",
 }));
 

--- a/src/cli/commands/onboard.ts
+++ b/src/cli/commands/onboard.ts
@@ -149,8 +149,8 @@ tools:
   - terminal
   - browser
 
-# Working mode: "always-ask" | "viber-decides" | "always-execute"
-workingMode: viber-decides
+# Working mode: "always_ask" | "agent_decides" | "always_execute"
+workingMode: agent_decides
 `;
       await fs.writeFile(defaultViberPath, defaultViber);
       console.log(`\n  ✓ Created viber.yaml`);


### PR DESCRIPTION
This PR addresses several pieces of outdated documentation and CLI configuration:

1. Updates `docs/concepts/skills.md` to use the correct `npx openviber status` and `npx openviber skill import` commands.
2. Updates `docs/design/openclaw-feature-comparison.md` to reference `npx openviber status` instead of `viber doctor`.
3. Updates the `npx openviber onboard` command to generate the `workingMode` as `agent_decides` rather than `viber-decides` in the default configuration template, aligning it with the supported types.
4. Fixes an issue in `src/cli/auth.test.ts` where it was mocking the wrong module (`../core/config-runtime` instead of `../utils/paths`), which caused side-effects during tests.

---
*PR created automatically by Jules for task [8785250528368005159](https://jules.google.com/task/8785250528368005159) started by @hughlv*